### PR TITLE
Implemented Receive Functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lurk_lcsc"
-version = "2.3.7"
+version = "2.3.8"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lurk_lcsc"
-version = "2.3.7"
+version = "2.3.8"
 authors = ["Riley Ziegler", "S. Seth Long, Ph.D"]
 categories = ["network-programming"]
 description = "LCSC LURK Protocol written in Rust"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # lurk_lcsc
 
-A Rust library for building **LURK protocol** servers and clients.  
-This crate implements the [LURK Protocol](https://github.com/The24Kings/LurkProtocol/wiki), enabling MUD text-based MMORPG games over the network.
-
-> [!NOTE]
-> I probably won't be adding anything more to this, or creating documentation, go read the wiki.
+A Rust library for building **Lurk protocol** servers and clients.  
+This crate implements the [Lurk Protocol](https://github.com/The24Kings/LurkProtocol/wiki), enabling MUD text-based MMORPG games over the network.
 
 ---
 
 ## Features
 
-- Provides core data structures for LURK messages (character, room, etc.)
-- Handles parsing and serialization of LURK protocol messages from TcpStream
+- Provides core data structures for Lurk messages (character, room, etc.)
+- Handles parsing and serialization of Lurk protocol messages from TcpStream
 - Ready to be used in both **client** and **server** implementations
 
 ### Optional Features
@@ -26,5 +23,5 @@ Add `lurk_lcsc` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lurk_lcsc = { version = "2.3.7" }
+lurk_lcsc = { version = "2.3.8" }
 ```

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 use serde::Serialize;
 
 bitflags! {
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+    #[derive(Default, Debug, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
     /// Flags representing the state of a character in the game.
     ///
     /// - When a client uses `PktType::CHARACTER` to describe a new player, the server may (should) ignore the client's initial specification for health, gold, and room.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,6 @@
     clippy::missing_errors_doc,
     clippy::must_use_candidate,
 )]
-// Restrictions
-#![deny(clippy::question_mark_used)]
 // Rustc lints.
 #![deny(missing_docs, unused_imports)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Lurk types in rustdoc of other crates get linked to here.
-#![doc(html_root_url = "https://docs.rs/lurk_lcsc/2.3.7")]
+#![doc(html_root_url = "https://docs.rs/lurk_lcsc/2.3.8")]
 // Show which crate feature enables conditionally compiled APIs in documentation.
 #![cfg_attr(docsrs, feature(doc_cfg, rustdoc_internals))]
 #![cfg_attr(docsrs, allow(internal_features))]
@@ -53,7 +53,6 @@
     clippy::too_many_lines,
     // preference
     clippy::doc_markdown,
-    clippy::elidable_lifetime_names,
     clippy::needless_lifetimes,
     clippy::unseparated_literal_suffix,
     // false positive
@@ -79,7 +78,7 @@ pub use packet::{
 pub use pkt_type::PktType;
 pub use protocol::Protocol;
 
-/// Types and utilities for character flags.
+/// Structures and utilities for character flags.
 pub mod flags;
 /// Error types for the Lurk protocol.
 pub mod lurk_error;
@@ -90,7 +89,7 @@ pub mod packet;
 pub mod pcap;
 /// Packet type definitions.
 pub mod pkt_type;
-/// Protocol definitions and utilities.
+/// Protocol definitions.
 pub mod protocol;
 
 #[cfg(feature = "tracing")]

--- a/src/lurk_error.rs
+++ b/src/lurk_error.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// Represents possible error codes for the Lurk protocol.
-#[derive(Default, Serialize, PartialEq, Eq, Hash, Debug)]
+#[derive(Default, Debug, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum LurkError {
     #[default]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -43,11 +43,11 @@ pub mod version;
 /// Trait for serializing and deserializing packets.
 ///
 /// ```no_run
+/// use lurk_lcsc::packet::{Packet, Parser};
+/// use lurk_lcsc::pkt_type::PktType;
 /// use serde::Serialize;
 /// use std::io::Write;
 ///
-/// use lurk_lcsc::pkt_type::PktType;
-/// use lurk_lcsc::packet::{Packet, Parser};
 ///
 /// pub struct PktLoot {
 ///    pub message_type: PktType,
@@ -64,12 +64,10 @@ pub mod version;
 ///         packet.extend(target_name_bytes);
 ///
 ///         // Write the packet to the buffer
-///         writer.write_all(&packet).map_err(|_| {
-///             std::io::Error::new(
-///                 std::io::ErrorKind::Other,
-///                 "Failed to write packet to buffer",
-///             )
-///         })?;
+///         writer
+///             .write_all(&packet)
+///             .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
+///
 ///         Ok(())
 ///     }
 ///
@@ -93,11 +91,11 @@ pub trait Parser<'a>: Sized + 'a {
     /// Deserializes a Packet into the implementing type.
     ///
     /// ```no_run
+    /// use lurk_lcsc::{Protocol, PktType, PktMessage, Packet, Parser};
     /// use std::io::{Read, Error, ErrorKind};
     /// use std::sync::{Arc, mpsc};
     /// use std::net::TcpStream;
     ///
-    /// use lurk_lcsc::{Protocol, PktType, PktMessage, Packet, Parser};
     ///
     /// let stream = Arc::new(TcpStream::connect("127.0.0.1:8080").unwrap());
     ///

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -43,8 +43,7 @@ pub mod version;
 /// Trait for serializing and deserializing packets.
 ///
 /// ```no_run
-/// use lurk_lcsc::packet::{Packet, Parser};
-/// use lurk_lcsc::pkt_type::PktType;
+/// use lurk_lcsc::{Packet, Parser, PktType};
 /// use serde::Serialize;
 /// use std::io::Write;
 ///
@@ -72,7 +71,7 @@ pub mod version;
 ///     }
 ///
 ///     fn deserialize(packet: Packet) -> Self {
-///         let message_type = packet.message_type;
+///         let message_type = packet.packet_type;
 ///         let target_name = String::from_utf8_lossy(&packet.body[0..32])
 ///             .trim_end_matches('\0')
 ///             .into();
@@ -135,25 +134,25 @@ pub trait Parser<'a>: Sized + 'a {
 /// use lurk_lcsc::packet::Packet;
 ///
 /// let stream = Arc::new(TcpStream::connect("127.0.0.1:8080").unwrap());
-/// let message_type = PktType::DEFAULT; // Replace with an actual variant
+/// let packet_type = PktType::DEFAULT; // Replace with an actual variant
 /// let body = &[0u8; 32];
-/// let packet = Packet::new(&stream, message_type, body);
+/// let packet = Packet::new(&stream, packet_type, body);
 /// ```
 pub struct Packet<'a> {
     /// Reference to the TCP stream associated with this packet.
     pub stream: &'a Arc<TcpStream>,
     /// The type of the packet message.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The body of the packet containing the raw bytes.
     pub body: &'a [u8],
 }
 
 impl<'a> Packet<'a> {
     /// Creates a new `Packet` instance from the given TCP stream, message type, and byte slice.
-    pub fn new(stream: &'a Arc<TcpStream>, message_type: PktType, bytes: &'a [u8]) -> Self {
+    pub fn new(stream: &'a Arc<TcpStream>, packet_type: PktType, bytes: &'a [u8]) -> Self {
         Packet {
             stream,
-            message_type,
+            packet_type,
             body: &bytes[0..],
         }
     }
@@ -162,7 +161,7 @@ impl<'a> Packet<'a> {
     /// This function reads the packet body based on the provided buffer length.
     pub fn read_into<'b>(
         stream: &'b Arc<TcpStream>,
-        message_type: PktType,
+        packet_type: PktType,
         buffer: &'b mut [u8],
     ) -> Result<Packet<'b>, std::io::Error> {
         // Read the remaining bytes for the packet
@@ -177,7 +176,7 @@ impl<'a> Packet<'a> {
         debug!("[DEBUG] Packet body:\n{}", PCap::build(buffer.to_vec()));
 
         // Create a new packet with the read bytes
-        let packet = Packet::new(stream, message_type, buffer);
+        let packet = Packet::new(stream, packet_type, buffer);
 
         Ok(packet)
     }
@@ -187,7 +186,7 @@ impl<'a> Packet<'a> {
     /// based on the provided index.
     pub fn read_extended<'b>(
         stream: &'b Arc<TcpStream>,
-        message_type: PktType,
+        packet_type: PktType,
         buffer: &'b mut Vec<u8>,
         index: (usize, usize),
     ) -> Result<Packet<'b>, std::io::Error> {
@@ -229,7 +228,7 @@ impl<'a> Packet<'a> {
         // Extend the buffer with the description
         buffer.extend_from_slice(&desc);
 
-        let packet = Packet::new(stream, message_type, buffer);
+        let packet = Packet::new(stream, packet_type, buffer);
 
         Ok(packet)
     }

--- a/src/packet/accept.rs
+++ b/src/packet/accept.rs
@@ -46,20 +46,17 @@ impl Parser<'_> for PktAccept {
         packet.extend(self.accept_type.to_le_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
-        Ok(PktAccept {
+    fn deserialize(packet: Packet) -> Self {
+        Self {
             message_type: packet.message_type,
             accept_type: packet.body[0],
-        })
+        }
     }
 }

--- a/src/packet/accept.rs
+++ b/src/packet/accept.rs
@@ -11,7 +11,7 @@ use crate::{Packet, Parser};
 #[derive(Serialize)]
 pub struct PktAccept {
     /// The type of message for the `ACCEPT` packet. Default is 8.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The type of action accepted.
     pub accept_type: u8,
 }
@@ -20,7 +20,7 @@ impl PktAccept {
     /// Creates a new `PktAccept` with the specified accept type.
     pub fn new(accept_type: PktType) -> Self {
         Self {
-            message_type: PktType::ACCEPT,
+            packet_type: PktType::ACCEPT,
             accept_type: accept_type.into(),
         }
     }
@@ -42,7 +42,7 @@ impl Parser<'_> for PktAccept {
         // Package into a byte array
         let mut packet: Vec<u8> = Vec::new();
 
-        packet.push(self.message_type.into());
+        packet.push(self.packet_type.into());
         packet.extend(self.accept_type.to_le_bytes());
 
         // Write the packet to the buffer
@@ -55,7 +55,7 @@ impl Parser<'_> for PktAccept {
 
     fn deserialize(packet: Packet) -> Self {
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             accept_type: packet.body[0],
         }
     }

--- a/src/packet/change_room.rs
+++ b/src/packet/change_room.rs
@@ -11,7 +11,7 @@ use crate::{Packet, Parser};
 #[derive(Serialize)]
 pub struct PktChangeRoom {
     /// The type of message for the `CHANGEROOM` packet. Default is 2.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// Number of the room to change to. The server will send an error if an inappropriate choice is made.
     pub room_number: u16,
 }
@@ -30,7 +30,7 @@ impl std::fmt::Display for PktChangeRoom {
 impl Parser<'_> for PktChangeRoom {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.room_number.to_le_bytes());
 
@@ -47,7 +47,7 @@ impl Parser<'_> for PktChangeRoom {
 
         // Implement deserialization logic here
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             room_number,
         }
     }

--- a/src/packet/change_room.rs
+++ b/src/packet/change_room.rs
@@ -35,23 +35,20 @@ impl Parser<'_> for PktChangeRoom {
         packet.extend(self.room_number.to_le_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
 
         // Implement deserialization logic here
-        Ok(PktChangeRoom {
+        Self {
             message_type: packet.message_type,
             room_number,
-        })
+        }
     }
 }

--- a/src/packet/character.rs
+++ b/src/packet/character.rs
@@ -96,17 +96,14 @@ impl Parser<'_> for PktCharacter {
         packet.extend(self.description.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let name = String::from_utf8_lossy(&packet.body[0..32])
             .split('\0')
             .take(1)
@@ -121,7 +118,7 @@ impl Parser<'_> for PktCharacter {
         let description_len = u16::from_le_bytes([packet.body[45], packet.body[46]]);
         let description = String::from_utf8_lossy(&packet.body[47..]).into();
 
-        Ok(PktCharacter {
+        Self {
             author: Some(packet.stream.clone()),
             message_type: packet.message_type,
             name: Arc::from(name),
@@ -134,6 +131,6 @@ impl Parser<'_> for PktCharacter {
             current_room,
             description_len,
             description,
-        })
+        }
     }
 }

--- a/src/packet/character.rs
+++ b/src/packet/character.rs
@@ -24,7 +24,7 @@ pub struct PktCharacter {
     /// The TCP stream associated with the author of the packet, if available.
     pub author: Option<Arc<TcpStream>>,
     /// The type of message for the `CHARACTER` packet. Default is 10.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The name of the character, up to 32 bytes.
     pub name: Arc<str>,
     /// The character's flags, represented as a bitfield.
@@ -74,7 +74,7 @@ impl std::fmt::Display for PktCharacter {
 impl Parser<'_> for PktCharacter {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         // Serialize the character name
         let mut name_bytes = self.name.as_bytes().to_vec();
@@ -120,7 +120,7 @@ impl Parser<'_> for PktCharacter {
 
         Self {
             author: Some(packet.stream.clone()),
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             name: Arc::from(name),
             flags,
             attack,

--- a/src/packet/connection.rs
+++ b/src/packet/connection.rs
@@ -17,7 +17,7 @@ use crate::{Packet, Parser};
 /// `Servers line the walls, softly lighting the room in a cacophony of red, green, blue, and yellow flashes`.
 pub struct PktConnection {
     /// The type of message for the `CONNECTION` packet. Defaults to 13.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// Room number. This is the same room number used for `PktType::CHANGEROOM`
     pub room_number: u16,
     /// The name of the room this connection leads to, up to 32 bytes.
@@ -42,7 +42,7 @@ impl std::fmt::Display for PktConnection {
 impl Parser<'_> for PktConnection {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.room_number.to_le_bytes());
 
@@ -62,7 +62,7 @@ impl Parser<'_> for PktConnection {
     }
 
     fn deserialize(packet: Packet) -> Self {
-        let message_type = packet.message_type;
+        let message_type = packet.packet_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
             .trim_end_matches('\0')
@@ -71,7 +71,7 @@ impl Parser<'_> for PktConnection {
         let description = String::from_utf8_lossy(&packet.body[36..]).into();
 
         Self {
-            message_type,
+            packet_type: message_type,
             room_number,
             room_name,
             description_len,

--- a/src/packet/connection.rs
+++ b/src/packet/connection.rs
@@ -54,17 +54,14 @@ impl Parser<'_> for PktConnection {
         packet.extend(self.description.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_type = packet.message_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
@@ -73,12 +70,12 @@ impl Parser<'_> for PktConnection {
         let description_len = u16::from_le_bytes([packet.body[34], packet.body[35]]);
         let description = String::from_utf8_lossy(&packet.body[36..]).into();
 
-        Ok(PktConnection {
+        Self {
             message_type,
             room_number,
             room_name,
             description_len,
             description,
-        })
+        }
     }
 }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -57,17 +57,14 @@ impl Parser<'_> for PktError {
         packet.extend(self.message.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_type = packet.message_type;
         let error = LurkError::from(packet.body[0]);
         let message_len = u16::from_le_bytes([packet.body[1], packet.body[2]]);
@@ -75,11 +72,11 @@ impl Parser<'_> for PktError {
             .trim_end_matches('\0')
             .into();
 
-        Ok(PktError {
+        Self {
             message_type,
             error,
             message_len,
             message,
-        })
+        }
     }
 }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -13,7 +13,7 @@ use crate::{Packet, Parser};
 #[derive(Serialize)]
 pub struct PktError {
     /// The type of message for the `ERROR` packet. Defaults to 7.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The specific error code.
     pub error: LurkError,
     /// The length of the error message.
@@ -29,7 +29,7 @@ impl PktError {
         error!("[SERVER] {}: {}", error, message);
 
         Self {
-            message_type: PktType::ERROR,
+            packet_type: PktType::ERROR,
             error,
             message_len: message.len() as u16,
             message: Box::from(message),
@@ -50,7 +50,7 @@ impl std::fmt::Display for PktError {
 impl Parser<'_> for PktError {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.push(self.error.into());
         packet.extend(self.message_len.to_le_bytes());
@@ -65,7 +65,7 @@ impl Parser<'_> for PktError {
     }
 
     fn deserialize(packet: Packet) -> Self {
-        let message_type = packet.message_type;
+        let message_type = packet.packet_type;
         let error = LurkError::from(packet.body[0]);
         let message_len = u16::from_le_bytes([packet.body[1], packet.body[2]]);
         let message = String::from_utf8_lossy(&packet.body[3..])
@@ -73,7 +73,7 @@ impl Parser<'_> for PktError {
             .into();
 
         Self {
-            message_type,
+            packet_type: message_type,
             error,
             message_len,
             message,

--- a/src/packet/fight.rs
+++ b/src/packet/fight.rs
@@ -46,19 +46,16 @@ impl Parser<'_> for PktFight {
         let packet: Vec<u8> = vec![self.message_type.into()];
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
-        Ok(PktFight {
+    fn deserialize(packet: Packet) -> Self {
+        Self {
             message_type: packet.message_type,
-        })
+        }
     }
 }

--- a/src/packet/fight.rs
+++ b/src/packet/fight.rs
@@ -19,13 +19,13 @@ use crate::{Packet, Parser};
 /// Note that this is not the only way a fight against monsters can be initiated. The server can initiate a fight at any time.
 pub struct PktFight {
     /// The type of message for the `FIGHT` packet. Defaults to 3.
-    pub message_type: PktType,
+    pub packet_type: PktType,
 }
 
 impl Default for PktFight {
     fn default() -> Self {
         Self {
-            message_type: PktType::FIGHT,
+            packet_type: PktType::FIGHT,
         }
     }
 }
@@ -43,7 +43,7 @@ impl std::fmt::Display for PktFight {
 impl Parser<'_> for PktFight {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let packet: Vec<u8> = vec![self.message_type.into()];
+        let packet: Vec<u8> = vec![self.packet_type.into()];
 
         // Write the packet to the buffer
         writer
@@ -55,7 +55,7 @@ impl Parser<'_> for PktFight {
 
     fn deserialize(packet: Packet) -> Self {
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
         }
     }
 }

--- a/src/packet/game.rs
+++ b/src/packet/game.rs
@@ -46,28 +46,25 @@ impl Parser<'_> for PktGame {
         packet.extend(self.description.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let initial_points = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let stat_limit = u16::from_le_bytes([packet.body[2], packet.body[3]]);
         let description_len = u16::from_le_bytes([packet.body[4], packet.body[5]]);
         let description = String::from_utf8_lossy(&packet.body[6..]).into();
 
-        Ok(PktGame {
+        Self {
             message_type: packet.message_type,
             initial_points,
             stat_limit,
             description_len,
             description,
-        })
+        }
     }
 }

--- a/src/packet/game.rs
+++ b/src/packet/game.rs
@@ -14,7 +14,7 @@ use crate::{Packet, Parser};
 /// This message will be sent upon connecting to the server, and not re-sent.
 pub struct PktGame {
     /// The type of message for the `GAME` packet. Defaults to 11.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The initial points available to a new character.
     pub initial_points: u16,
     /// The maximum stat limit for any character.
@@ -38,7 +38,7 @@ impl std::fmt::Display for PktGame {
 impl Parser<'_> for PktGame {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.initial_points.to_le_bytes());
         packet.extend(self.stat_limit.to_le_bytes());
@@ -60,7 +60,7 @@ impl Parser<'_> for PktGame {
         let description = String::from_utf8_lossy(&packet.body[6..]).into();
 
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             initial_points,
             stat_limit,
             description_len,

--- a/src/packet/leave.rs
+++ b/src/packet/leave.rs
@@ -35,19 +35,16 @@ impl Parser<'_> for PktLeave {
         let packet: Vec<u8> = vec![self.message_type.into()];
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
-        Ok(PktLeave {
+    fn deserialize(packet: Packet) -> Self {
+        Self {
             message_type: packet.message_type,
-        })
+        }
     }
 }

--- a/src/packet/leave.rs
+++ b/src/packet/leave.rs
@@ -8,13 +8,13 @@ use crate::{Packet, Parser};
 /// Used by the client to leave the game. This is a graceful way to disconnect. The server never terminates, so it doesn't send `PktType::LEAVE`.
 pub struct PktLeave {
     /// The type of message for the `LEAVE` packet. Defaults to 12.
-    pub message_type: PktType,
+    pub packet_type: PktType,
 }
 
 impl Default for PktLeave {
     fn default() -> Self {
         Self {
-            message_type: PktType::LEAVE,
+            packet_type: PktType::LEAVE,
         }
     }
 }
@@ -32,7 +32,7 @@ impl std::fmt::Display for PktLeave {
 impl Parser<'_> for PktLeave {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let packet: Vec<u8> = vec![self.message_type.into()];
+        let packet: Vec<u8> = vec![self.packet_type.into()];
 
         // Write the packet to the buffer
         writer
@@ -44,7 +44,7 @@ impl Parser<'_> for PktLeave {
 
     fn deserialize(packet: Packet) -> Self {
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
         }
     }
 }

--- a/src/packet/loot.rs
+++ b/src/packet/loot.rs
@@ -8,7 +8,7 @@ use crate::{Packet, Parser};
 #[derive(Serialize)]
 pub struct PktLoot {
     /// The type of the packet message.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The name of the loot target.
     pub target_name: Box<str>,
 }
@@ -26,7 +26,7 @@ impl std::fmt::Display for PktLoot {
 impl Parser<'_> for PktLoot {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         let mut target_name_bytes = self.target_name.as_bytes().to_vec();
         target_name_bytes.resize(32, 0x00); // Pad the name to 32 bytes
@@ -41,13 +41,13 @@ impl Parser<'_> for PktLoot {
     }
 
     fn deserialize(packet: Packet) -> Self {
-        let message_type = packet.message_type;
+        let message_type = packet.packet_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .trim_end_matches('\0')
             .into();
 
         Self {
-            message_type,
+            packet_type: message_type,
             target_name,
         }
     }

--- a/src/packet/loot.rs
+++ b/src/packet/loot.rs
@@ -33,25 +33,22 @@ impl Parser<'_> for PktLoot {
         packet.extend(target_name_bytes);
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_type = packet.message_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .trim_end_matches('\0')
             .into();
 
-        Ok(PktLoot {
+        Self {
             message_type,
             target_name,
-        })
+        }
     }
 }

--- a/src/packet/message.rs
+++ b/src/packet/message.rs
@@ -12,7 +12,7 @@ use crate::{Packet, Parser};
 /// - If using this to send game information, the server should mark the message as narration.
 pub struct PktMessage {
     /// The type of message for the `MESSAGE` packet. Defaults to 1.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The length of the message.
     pub message_len: u16,
     /// The recipient of the message, up to 32 bytes.
@@ -31,7 +31,7 @@ impl PktMessage {
     /// This is used for system messages, such as "You have been disconnected" or "Welcome to the game".
     pub fn server(recipient: &str, message: &str) -> Self {
         Self {
-            message_type: PktType::MESSAGE,
+            packet_type: PktType::MESSAGE,
             message_len: message.len() as u16,
             recipient: Box::from(recipient),
             sender: Box::from("Server"),
@@ -45,7 +45,7 @@ impl PktMessage {
     /// This is used for room descriptions and other narrative messages.
     pub fn narrator(recipient: &str, message: &str) -> Self {
         Self {
-            message_type: PktType::MESSAGE,
+            packet_type: PktType::MESSAGE,
             message_len: message.len() as u16,
             recipient: Box::from(recipient),
             sender: Box::from("Narrator"),
@@ -69,7 +69,7 @@ impl std::fmt::Display for PktMessage {
 impl Parser<'_> for PktMessage {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.message_len.to_le_bytes());
 
@@ -127,7 +127,7 @@ impl Parser<'_> for PktMessage {
         let message = String::from_utf8_lossy(&packet.body[66..]).into();
 
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             message_len,
             recipient,
             sender,

--- a/src/packet/message.rs
+++ b/src/packet/message.rs
@@ -93,17 +93,14 @@ impl Parser<'_> for PktMessage {
         packet.extend(self.message.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_len = u16::from_le_bytes([packet.body[0], packet.body[1]]);
 
         // Process the names for recipient and sender
@@ -129,13 +126,13 @@ impl Parser<'_> for PktMessage {
             .collect();
         let message = String::from_utf8_lossy(&packet.body[66..]).into();
 
-        Ok(PktMessage {
+        Self {
             message_type: packet.message_type,
             message_len,
             recipient,
             sender,
             narration,
             message,
-        })
+        }
     }
 }

--- a/src/packet/pvp_fight.rs
+++ b/src/packet/pvp_fight.rs
@@ -40,25 +40,22 @@ impl Parser<'_> for PktPVPFight {
         target_name_bytes.resize(32, 0x00); // Pad the name to 32 bytes
         packet.extend(target_name_bytes);
 
-        // Send the packet to the author
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        // Write the packet to the buffer
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_type = packet.message_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .trim_end_matches('\0')
             .to_string();
 
-        Ok(PktPVPFight {
+        Self {
             message_type,
             target_name,
-        })
+        }
     }
 }

--- a/src/packet/pvp_fight.rs
+++ b/src/packet/pvp_fight.rs
@@ -15,7 +15,7 @@ use crate::{Packet, Parser};
 /// If the server does not support PVP, it should send `LurkError::NOPLAYERCOMBAT` to the client.
 pub struct PktPVPFight {
     /// The type of message for the `PVPFIGHT` packet. Defaults to 4.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The name of the target player, up to 32 bytes.
     pub target_name: String,
 }
@@ -34,7 +34,7 @@ impl std::fmt::Display for PktPVPFight {
 impl Parser<'_> for PktPVPFight {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         let mut target_name_bytes = self.target_name.as_bytes().to_vec();
         target_name_bytes.resize(32, 0x00); // Pad the name to 32 bytes
@@ -48,13 +48,13 @@ impl Parser<'_> for PktPVPFight {
         Ok(())
     }
     fn deserialize(packet: Packet) -> Self {
-        let message_type = packet.message_type;
+        let message_type = packet.packet_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .trim_end_matches('\0')
             .to_string();
 
         Self {
-            message_type,
+            packet_type: message_type,
             target_name,
         }
     }

--- a/src/packet/room.rs
+++ b/src/packet/room.rs
@@ -49,17 +49,14 @@ impl Parser<'_> for PktRoom {
         packet.extend(self.description.as_bytes());
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
+    fn deserialize(packet: Packet) -> Self {
         let message_type = packet.message_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
@@ -68,12 +65,12 @@ impl Parser<'_> for PktRoom {
         let description_len = u16::from_le_bytes([packet.body[34], packet.body[35]]);
         let description = String::from_utf8_lossy(&packet.body[36..]).into();
 
-        Ok(PktRoom {
+        Self {
             message_type,
             room_number,
             room_name,
             description_len,
             description,
-        })
+        }
     }
 }

--- a/src/packet/room.rs
+++ b/src/packet/room.rs
@@ -13,7 +13,7 @@ use crate::{Packet, Parser};
 /// - Monsters and players in the room should be listed using a series of `PktType::CHARACTER` messages.
 pub struct PktRoom {
     /// The type of message for the `ROOM` packet. Defaults to 9
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The room number the player is currently in. This is the same as the room number used in `PktType::CHANGEROOM`.
     pub room_number: u16,
     /// The name of the room, up to 32 bytes.
@@ -37,7 +37,7 @@ impl std::fmt::Display for PktRoom {
 impl Parser<'_> for PktRoom {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.room_number.to_le_bytes());
 
@@ -57,7 +57,7 @@ impl Parser<'_> for PktRoom {
     }
 
     fn deserialize(packet: Packet) -> Self {
-        let message_type = packet.message_type;
+        let message_type = packet.packet_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
             .trim_end_matches('\0')
@@ -66,7 +66,7 @@ impl Parser<'_> for PktRoom {
         let description = String::from_utf8_lossy(&packet.body[36..]).into();
 
         Self {
-            message_type,
+            packet_type: message_type,
             room_number,
             room_name,
             description_len,

--- a/src/packet/start.rs
+++ b/src/packet/start.rs
@@ -39,19 +39,16 @@ impl Parser<'_> for PktStart {
         // Package into a byte array
         let packet: Vec<u8> = vec![self.message_type.into()];
 
-        // Send the packet to the author
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        // Write the packet to the buffer
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
-        Ok(PktStart {
+    fn deserialize(packet: Packet) -> Self {
+        Self {
             message_type: packet.message_type,
-        })
+        }
     }
 }

--- a/src/packet/start.rs
+++ b/src/packet/start.rs
@@ -13,13 +13,13 @@ use crate::{Packet, Parser};
 /// - Generally, the server will reply with a `PktType::ROOM`, a `PktType::CHARACTER` message showing the updated room, and a `PktType::CHARACTER` message for each player in the initial room of the game.
 pub struct PktStart {
     /// The type of message for the `START` packet. Defaults to 6.
-    pub message_type: PktType,
+    pub packet_type: PktType,
 }
 
 impl Default for PktStart {
     fn default() -> Self {
         PktStart {
-            message_type: PktType::START,
+            packet_type: PktType::START,
         }
     }
 }
@@ -37,7 +37,7 @@ impl std::fmt::Display for PktStart {
 impl Parser<'_> for PktStart {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let packet: Vec<u8> = vec![self.message_type.into()];
+        let packet: Vec<u8> = vec![self.packet_type.into()];
 
         // Write the packet to the buffer
         writer
@@ -48,7 +48,7 @@ impl Parser<'_> for PktStart {
     }
     fn deserialize(packet: Packet) -> Self {
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
         }
     }
 }

--- a/src/packet/version.rs
+++ b/src/packet/version.rs
@@ -16,8 +16,8 @@ pub struct PktVersion {
     /// The length of the extensions field.
     pub extension_len: u16,
     /// The extensions field:
-    /// - 0-1	Length of the first extension, as an unsigned 16-bit integer.
-    /// - 2+	First extension
+    /// - 0-1 Length of the first extension, as an unsigned 16-bit integer.
+    /// - 2+ First extension
     ///
     /// At the end of the first extension, if there are more extensions, the length of the second extension will be found, then the second extension, and so on.
     /// The length of the list of extensions must be the same as `extension_len`.
@@ -50,23 +50,20 @@ impl Parser<'_> for PktVersion {
         }
 
         // Write the packet to the buffer
-        writer.write_all(&packet).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to write packet to buffer",
-            )
-        })?;
+        writer
+            .write_all(&packet)
+            .map_err(|_| std::io::Error::other("Failed to write packet to buffer"))?;
 
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Result<Self, std::io::Error> {
-        Ok(PktVersion {
+    fn deserialize(packet: Packet) -> Self {
+        Self {
             message_type: packet.message_type,
             major_rev: packet.body[0],
             minor_rev: packet.body[1],
             extension_len: 0,
             extensions: None, // Server currently does not use extensions
-        })
+        }
     }
 }

--- a/src/packet/version.rs
+++ b/src/packet/version.rs
@@ -8,7 +8,7 @@ use crate::{Packet, Parser};
 /// Sent by the server upon initial connection along with `PktType::GAME`.
 pub struct PktVersion {
     /// The type of message for the `VERSION` packet. Defaults to 14.
-    pub message_type: PktType,
+    pub packet_type: PktType,
     /// The major revision number of the server.
     pub major_rev: u8,
     /// The minor revision number of the server.
@@ -39,7 +39,7 @@ impl std::fmt::Display for PktVersion {
 impl Parser<'_> for PktVersion {
     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
-        let mut packet: Vec<u8> = vec![self.message_type.into()];
+        let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
         packet.extend(self.major_rev.to_le_bytes());
         packet.extend(self.minor_rev.to_le_bytes());
@@ -59,7 +59,7 @@ impl Parser<'_> for PktVersion {
 
     fn deserialize(packet: Packet) -> Self {
         Self {
-            message_type: packet.message_type,
+            packet_type: packet.packet_type,
             major_rev: packet.body[0],
             minor_rev: packet.body[1],
             extension_len: 0,

--- a/src/pkt_type.rs
+++ b/src/pkt_type.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// Represents the different types of packets used in the application.
-#[derive(Default, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum PktType {
     #[default]

--- a/src/pkt_type.rs
+++ b/src/pkt_type.rs
@@ -57,7 +57,7 @@ impl From<PktType> for u8 {
 
 impl From<u8> for PktType {
     /// Converts a `u8` value into its corresponding `PktType` enum variant.
-    /// # Example
+    ///
     /// ```rust
     /// use lurk_lcsc::pkt_type::PktType;
     ///
@@ -66,6 +66,38 @@ impl From<u8> for PktType {
     /// ```
     fn from(value: u8) -> Self {
         match value {
+            0 => PktType::DEFAULT,
+            1 => PktType::MESSAGE,
+            2 => PktType::CHANGEROOM,
+            3 => PktType::FIGHT,
+            4 => PktType::PVPFIGHT,
+            5 => PktType::LOOT,
+            6 => PktType::START,
+            7 => PktType::ERROR,
+            8 => PktType::ACCEPT,
+            9 => PktType::ROOM,
+            10 => PktType::CHARACTER,
+            11 => PktType::GAME,
+            12 => PktType::LEAVE,
+            13 => PktType::CONNECTION,
+            14 => PktType::VERSION,
+            _ => PktType::DEFAULT,
+        }
+    }
+}
+
+impl From<&[u8; 1]> for PktType {
+    /// Converts a byte slice into its corresponding `PktType` enum variant.
+    ///
+    /// ```rust
+    /// use lurk_lcsc::pkt_type::PktType;
+    ///
+    /// let bytes = [3u8; 1];
+    /// let pkt_type = PktType::from(&bytes);
+    /// assert_eq!(pkt_type, PktType::FIGHT);
+    /// ```
+    fn from(value: &[u8; 1]) -> Self {
+        match value[0] {
             0 => PktType::DEFAULT,
             1 => PktType::MESSAGE,
             2 => PktType::CHANGEROOM,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -88,9 +88,8 @@ impl Protocol {
     /// use std::net::TcpStream;
     /// use std::sync::Arc;
     ///
-    /// // Assume you have a TcpStream and a PktMessage
     /// let stream = Arc::new(TcpStream::connect("127.0.0.1:8080").unwrap());
-    /// let pkt_message = PktMessage::server("Recipient", "Hello, server!");
+    /// let pkt_message = PktMessage::server("Recipient", "Message");
     ///
     /// // Send the packet
     /// Protocol::Message(stream.clone(), pkt_message).send().unwrap();
@@ -174,33 +173,15 @@ impl Protocol {
     /// ```no_run
     /// use lurk_lcsc::{Protocol, PktLeave};
     /// use std::io::{Error, ErrorKind};
-    /// use std::sync::{Arc, mpsc};
     /// use std::net::TcpStream;
+    /// use std::sync::Arc;
     ///
     /// let stream = Arc::new(TcpStream::connect("127.0.0.1:8080").unwrap());
-    /// let (sender, receiver) = mpsc::channel();
     ///
     /// loop {
     ///     let packet = match Protocol::recv(&stream) {
     ///         Ok(pkt) => pkt,
-    ///         Err(e) => {
-    ///             match e.kind() {
-    ///                 ErrorKind::UnexpectedEof | ErrorKind::Unsupported => {
-    ///                     eprintln!("[READ] '{:?}' -> {}. Terminating.", e.kind(), e);
-    ///                 }
-    ///                 _ => {
-    ///                     eprintln!("[READ] '{:?}' -> {}. Continuing.", e.kind(), e);
-    ///                     continue; // Continue processing other packets
-    ///                 }
-    ///             }
-    ///
-    ///             // Exit gracefully
-    ///             sender
-    ///                 .send(Protocol::Leave(stream.clone(), PktLeave::default()))
-    ///                 .unwrap();
-    ///             
-    ///             break;
-    ///         }
+    ///         Err(e) => todo!("Handle any errors"),
     ///     };
     ///
     ///     todo!("Send packet to server")

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -189,12 +189,8 @@ impl Protocol {
     /// ```
     pub fn recv(stream: &Arc<TcpStream>) -> Result<Protocol, std::io::Error> {
         let mut buffer = [0; 1];
-        let bytes_read = stream.as_ref().read(&mut buffer)?;
-        let packet_type = buffer[0].into();
-
-        if bytes_read != 1 {
-            return Err(Error::new(ErrorKind::UnexpectedEof, "Connection closed"));
-        }
+        stream.as_ref().read_exact(&mut buffer)?;
+        let packet_type = PktType::from(&buffer);
 
         #[cfg(feature = "tracing")]
         info!("[PROTOCOL] Read packet type: {}", packet_type);


### PR DESCRIPTION
- Migrated receiving packets to the API over server impl
- Small refactors
- Documentation updates
- `message_type` is now `packet_type` to better reflect what it is
- `deserialize` trait now returns `Self` rather than `Result` because deserialization shouldn't fail.
  - *If it does something catastrophic has happened and the client should bail anyways.*