### PR TITLE
Improved send API and reduce unnecessary cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lurk_lcsc"
-version = "2.3.13"
+version = "2.3.14"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lurk_lcsc"
-version = "2.3.13"
+version = "2.3.14"
 authors = ["Riley Ziegler", "S. Seth Long, Ph.D"]
 categories = ["network-programming"]
 description = "LCSC LURK Protocol written in Rust"

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Add `lurk_lcsc` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lurk_lcsc = { version = "2.3.13" }
+lurk_lcsc = { version = "2.3.14" }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Lurk types in rustdoc of other crates get linked to here.
-#![doc(html_root_url = "https://docs.rs/lurk_lcsc/2.3.13")]
+#![doc(html_root_url = "https://docs.rs/lurk_lcsc/2.3.14")]
 // Show which crate feature enables conditionally compiled APIs in documentation.
 #![cfg_attr(docsrs, feature(doc_cfg, rustdoc_internals))]
 #![cfg_attr(docsrs, allow(internal_features))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+use std::io::Write;
+use std::net::TcpStream;
+
 pub use flags::CharacterFlags;
 pub use lurk_error::LurkError;
 #[doc(hidden)]
@@ -166,7 +169,7 @@ pub mod packet;
 /// let packet = PktMessage::server("Player1", "Welcome to the game!");
 ///
 /// let mut buffer: Vec<u8> = Vec::new();
-/// packet.serialize(&mut buffer).unwrap();
+/// packet.write_to(&mut buffer).unwrap();
 ///
 /// println!("{}", PCap::build(buffer));
 /// ```
@@ -183,3 +186,22 @@ pub use pcap::PCap;
 #[doc(hidden)]
 #[allow(dead_code)] // Suppress unused warning as this module is used in multiple test modules.
 pub(crate) mod test_common;
+
+/// Serialize a packet and write it directly to a [`TcpStream`].
+pub fn send_to<'a>(
+    stream: &TcpStream,
+    packet: &(impl Parser<'a> + std::fmt::Display),
+) -> Result<(), std::io::Error> {
+    let mut buf = Vec::new();
+
+    #[cfg(feature = "tracing")]
+    tracing::info!("Sending packet: {}", packet);
+
+    packet.write_to(&mut buf)?;
+
+    #[cfg(feature = "tracing")]
+    tracing::trace!("Packet:\n{}", PCap::build(buf.clone()));
+
+    let mut writer = stream;
+    writer.write_all(&buf)
+}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -48,16 +48,16 @@ pub mod version;
 /// ```no_run
 /// use lurk_lcsc::{Packet, Parser, PktType};
 /// use std::io::{Error, Write};
-/// use serde::Serialize;
+/// use serde::{Deserialize, Serialize};
 ///
-///
+/// #[derive(Serialize, Deserialize)]
 /// pub struct PktLoot {
 ///    pub message_type: PktType,
 ///    pub target_name: Box<str>,
 ///}
 ///
 /// impl Parser<'_> for PktLoot {
-///     fn serialize<W: Write>(self, writer: &mut W) -> Result<(), Error> {
+///     fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
 ///         // Package into a byte array
 ///         let mut packet: Vec<u8> = vec![self.message_type.into()];
 ///
@@ -73,7 +73,7 @@ pub mod version;
 ///         Ok(())
 ///     }
 ///
-///     fn deserialize(packet: Packet) -> Self {
+///     fn decode(packet: Packet) -> Self {
 ///         let message_type = packet.packet_type;
 ///         let target_name = String::from_utf8_lossy(&packet.body[0..32])
 ///             .trim_end_matches('\0')
@@ -103,9 +103,9 @@ pub trait Parser<'a>: Sized + 'a {
     /// };
     ///
     /// let mut buffer: Vec<u8> = Vec::new();
-    /// packet.serialize(&mut buffer).unwrap();
+    /// packet.write_to(&mut buffer).unwrap();
     /// ```
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), Error>;
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Error>;
 
     /// Deserializes a Packet into the implementing type.
     ///
@@ -131,14 +131,14 @@ pub trait Parser<'a>: Sized + 'a {
     ///
     ///        Ok(Protocol::Message(
     ///            stream.clone(),
-    ///            PktMessage::deserialize(pkt),
+    ///            PktMessage::decode(pkt),
     ///        ))
     ///    },
     ///     _ => todo!("Handle other packet types"),
     ///     PktType::DEFAULT => Err(Error::new(ErrorKind::Unsupported, "Invalid packet type")),
     /// };
     /// ```
-    fn deserialize(packet: Packet) -> Self;
+    fn decode(packet: Packet) -> Self;
 }
 
 /// Represents a network packet containing a reference to the TCP stream, packet type, and body.

--- a/src/packet/accept.rs
+++ b/src/packet/accept.rs
@@ -39,7 +39,7 @@ impl PktAccept {
 /// ```
 macro_rules! send_accept {
     ($stream:expr, $p_type:expr) => {
-        if let Err(e) = $crate::Protocol::Accept($stream, $crate::PktAccept::new($p_type)).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$crate::PktAccept::new($p_type)) {
             eprintln!("Failed to send 'ACCEPT' packet: {}", e);
         }
     };
@@ -57,7 +57,7 @@ impl std::fmt::Display for PktAccept {
 }
 
 impl Parser<'_> for PktAccept {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = Vec::new();
 
@@ -72,7 +72,7 @@ impl Parser<'_> for PktAccept {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         Self {
             packet_type: packet.packet_type,
             accept_type: packet.body[0],
@@ -96,7 +96,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktAccept
-        let message = <PktAccept as Parser>::deserialize(packet);
+        let message = PktAccept::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::ACCEPT);
@@ -104,9 +104,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -119,7 +117,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x0a]; // CHARACTER = 10
         let packet = Packet::new(&stream, PktType::ACCEPT, body);
-        let acc = <PktAccept as Parser>::deserialize(packet);
+        let acc = PktAccept::decode(packet);
 
         assert_eq!(acc.accept_type, 10);
         assert_eq!(acc.accept_type, u8::from(PktType::CHARACTER));
@@ -153,10 +151,10 @@ mod tests {
 
             // Serialize and deserialize roundtrip
             let mut buffer: Vec<u8> = Vec::new();
-            acc.serialize(&mut buffer).expect("Serialization failed");
+            acc.write_to(&mut buffer).expect("Encoding failed");
 
             let packet = Packet::new(&stream, PktType::ACCEPT, &buffer[1..]);
-            let deserialized = <PktAccept as Parser>::deserialize(packet);
+            let deserialized = PktAccept::decode(packet);
             assert_eq!(deserialized.accept_type, u8::from(pkt_type));
         }
     }
@@ -167,7 +165,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF];
         let packet = Packet::new(&stream, PktType::ACCEPT, body);
-        let acc = <PktAccept as Parser>::deserialize(packet);
+        let acc = PktAccept::decode(packet);
 
         assert_eq!(acc.accept_type, 255);
     }
@@ -178,7 +176,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00];
         let packet = Packet::new(&stream, PktType::ACCEPT, body);
-        let acc = <PktAccept as Parser>::deserialize(packet);
+        let acc = PktAccept::decode(packet);
 
         assert_eq!(acc.accept_type, 0);
     }
@@ -190,16 +188,14 @@ mod tests {
         let original = PktAccept::new(PktType::MESSAGE);
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         assert_eq!(buffer.len(), 2);
         assert_eq!(buffer[0], u8::from(PktType::ACCEPT));
         assert_eq!(buffer[1], u8::from(PktType::MESSAGE));
 
         let packet = Packet::new(&stream, PktType::ACCEPT, &buffer[1..]);
-        let deserialized = <PktAccept as Parser>::deserialize(packet);
+        let deserialized = PktAccept::decode(packet);
         assert_eq!(deserialized.accept_type, u8::from(PktType::MESSAGE));
     }
 
@@ -210,7 +206,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::ACCEPT, body);
-        let _ = <PktAccept as Parser>::deserialize(packet);
+        let _ = PktAccept::decode(packet);
     }
 
     /// Extra trailing bytes should be ignored.
@@ -219,7 +215,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x0a, 0xFF, 0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::ACCEPT, body);
-        let acc = <PktAccept as Parser>::deserialize(packet);
+        let acc = PktAccept::decode(packet);
 
         assert_eq!(acc.accept_type, 10);
     }

--- a/src/packet/change_room.rs
+++ b/src/packet/change_room.rs
@@ -47,7 +47,7 @@ impl From<PktChangeRoom> for u16 {
 /// ```
 macro_rules! send_change_room {
     ($stream:expr, $pkt_chg_rm:expr) => {
-        if let Err(e) = $crate::Protocol::ChangeRoom($stream, $pkt_chg_rm).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_chg_rm) {
             eprintln!("Failed to send change room packet: {}", e);
         }
     };
@@ -65,7 +65,7 @@ impl std::fmt::Display for PktChangeRoom {
 }
 
 impl Parser<'_> for PktChangeRoom {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -79,7 +79,7 @@ impl Parser<'_> for PktChangeRoom {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
 
         // Implement deserialization logic here
@@ -106,7 +106,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktChangeRoom
-        let message = <PktChangeRoom as Parser>::deserialize(packet);
+        let message = PktChangeRoom::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::CHANGEROOM);
@@ -114,9 +114,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -145,7 +143,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00];
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let cr = <PktChangeRoom as Parser>::deserialize(packet);
+        let cr = PktChangeRoom::decode(packet);
         assert_eq!(cr.room_number, 0);
     }
 
@@ -155,7 +153,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x01, 0x00];
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let cr = <PktChangeRoom as Parser>::deserialize(packet);
+        let cr = PktChangeRoom::decode(packet);
         assert_eq!(cr.room_number, 1);
     }
 
@@ -165,7 +163,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let cr = <PktChangeRoom as Parser>::deserialize(packet);
+        let cr = PktChangeRoom::decode(packet);
         assert_eq!(cr.room_number, u16::MAX);
     }
 
@@ -176,10 +174,10 @@ mod tests {
         for &room in &[0u16, 1, 255, 256, 1000, u16::MAX - 1, u16::MAX] {
             let cr = PktChangeRoom::from(room);
             let mut buffer: Vec<u8> = Vec::new();
-            cr.serialize(&mut buffer).expect("Serialization failed");
+            cr.write_to(&mut buffer).expect("Encoding failed");
 
             let packet = Packet::new(&stream, PktType::CHANGEROOM, &buffer[1..]);
-            let deserialized = <PktChangeRoom as Parser>::deserialize(packet);
+            let deserialized = PktChangeRoom::decode(packet);
             assert_eq!(deserialized.room_number, room, "Failed for room: {}", room);
         }
     }
@@ -189,7 +187,7 @@ mod tests {
     fn changeroom_serialize_length() {
         let cr = PktChangeRoom::from(0u16);
         let mut buffer: Vec<u8> = Vec::new();
-        cr.serialize(&mut buffer).expect("Serialization failed");
+        cr.write_to(&mut buffer).expect("Encoding failed");
         assert_eq!(buffer.len(), 3);
     }
 
@@ -200,7 +198,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00]; // Need 2 bytes
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let _ = <PktChangeRoom as Parser>::deserialize(packet);
+        let _ = PktChangeRoom::decode(packet);
     }
 
     /// Empty body should panic.
@@ -210,7 +208,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let _ = <PktChangeRoom as Parser>::deserialize(packet);
+        let _ = PktChangeRoom::decode(packet);
     }
 
     /// Extra trailing bytes should be ignored.
@@ -219,7 +217,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x05, 0x00, 0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::CHANGEROOM, body);
-        let cr = <PktChangeRoom as Parser>::deserialize(packet);
+        let cr = PktChangeRoom::decode(packet);
         assert_eq!(cr.room_number, 5);
     }
 

--- a/src/packet/character.rs
+++ b/src/packet/character.rs
@@ -90,7 +90,7 @@ impl PktCharacter {
 /// ```
 macro_rules! send_character {
     ($stream:expr, $player:expr) => {
-        if let Err(e) = $crate::Protocol::Character($stream, $player).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$player) {
             eprintln!("Failed to send character packet: {}", e);
         }
     };
@@ -108,7 +108,7 @@ impl std::fmt::Display for PktCharacter {
 }
 
 impl Parser<'_> for PktCharacter {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -139,7 +139,7 @@ impl Parser<'_> for PktCharacter {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let name = String::from_utf8_lossy(&packet.body[0..32])
             .split('\0')
             .take(1)
@@ -194,7 +194,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktCharacter
-        let message = <PktCharacter as Parser>::deserialize(packet);
+        let message = PktCharacter::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::CHARACTER);
@@ -210,9 +210,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -240,7 +238,7 @@ mod tests {
         body.extend(0u16.to_le_bytes()); // description_len
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.name.as_ref(), "Test");
         assert!(chr.flags.contains(CharacterFlags::ALIVE));
@@ -276,7 +274,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert!(chr.flags.contains(CharacterFlags::ALIVE));
         assert!(chr.flags.contains(CharacterFlags::BATTLE));
@@ -305,7 +303,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.name.as_ref(), "Deku Baba");
         assert!(chr.flags.contains(CharacterFlags::ALIVE));
@@ -340,7 +338,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert!(!chr.flags.contains(CharacterFlags::ALIVE));
         assert!(chr.flags.contains(CharacterFlags::MONSTER));
@@ -365,7 +363,7 @@ mod tests {
         body.extend(0u16.to_le_bytes()); // description_len
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.attack, u16::MAX);
         assert_eq!(chr.defense, u16::MAX);
@@ -393,7 +391,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.health, i16::MIN);
     }
@@ -405,7 +403,7 @@ mod tests {
         let body: Vec<u8> = vec![0x00; 47]; // 32 name + 1 flags + 14 stats = 47
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.name.as_ref(), "");
         assert!(chr.flags.is_empty());
@@ -435,7 +433,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         assert_eq!(chr.name.as_ref(), &long_name);
     }
@@ -463,12 +461,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &buffer[1..]);
-        let deserialized = <PktCharacter as Parser>::deserialize(packet);
+        let deserialized = PktCharacter::decode(packet);
 
         assert_eq!(deserialized.name.as_ref(), "TestHero");
         assert_eq!(
@@ -499,7 +495,7 @@ mod tests {
         body.extend(vec![0u8; 14]); // stats
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         // Should contain replacement characters
         assert!(chr.name.contains('\u{FFFD}'));
@@ -512,7 +508,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x41; 20]; // Only 20 bytes, need at least 47
         let packet = Packet::new(&stream, PktType::CHARACTER, body);
-        let _ = <PktCharacter as Parser>::deserialize(packet);
+        let _ = PktCharacter::decode(packet);
     }
 
     /// Empty body should panic.
@@ -522,7 +518,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::CHARACTER, body);
-        let _ = <PktCharacter as Parser>::deserialize(packet);
+        let _ = PktCharacter::decode(packet);
     }
 
     /// Verify CharacterFlags helper methods work.
@@ -585,7 +581,7 @@ mod tests {
         let body: Vec<u8> = vec![0xFF; 47];
 
         let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-        let chr = <PktCharacter as Parser>::deserialize(packet);
+        let chr = PktCharacter::decode(packet);
 
         // Flags are truncated to known bits
         assert!(chr.flags.contains(CharacterFlags::ALIVE));
@@ -655,7 +651,7 @@ mod tests {
             body.extend(0u16.to_le_bytes()); // desc_len
 
             let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-            let chr = <PktCharacter as Parser>::deserialize(packet);
+            let chr = PktCharacter::decode(packet);
             assert_eq!(chr.health, health, "Failed for health value: {}", health);
         }
     }
@@ -680,7 +676,7 @@ mod tests {
             body.extend(0u16.to_le_bytes());
 
             let packet = Packet::new(&stream, PktType::CHARACTER, &body);
-            let chr = <PktCharacter as Parser>::deserialize(packet);
+            let chr = PktCharacter::decode(packet);
             assert_eq!(chr.gold, gold, "Failed for gold value: {}", gold);
         }
     }

--- a/src/packet/connection.rs
+++ b/src/packet/connection.rs
@@ -49,7 +49,7 @@ pub struct PktConnection {
 /// ```
 macro_rules! send_connection {
     ($stream:expr, $connection:expr) => {
-        if let Err(e) = $crate::Protocol::Connection($stream, $connection).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$connection) {
             eprintln!("Failed to send connection packet: {}", e);
         }
     };
@@ -67,7 +67,7 @@ impl std::fmt::Display for PktConnection {
 }
 
 impl Parser<'_> for PktConnection {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -88,7 +88,7 @@ impl Parser<'_> for PktConnection {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_type = packet.packet_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
@@ -131,7 +131,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktConnection
-        let message = <PktConnection as Parser>::deserialize(packet);
+        let message = PktConnection::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::CONNECTION);
@@ -145,9 +145,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -169,7 +167,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert_eq!(conn.room_number, 1);
         assert_eq!(conn.room_name.as_ref(), room_name);
@@ -188,7 +186,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert_eq!(conn.description_len, 0);
         assert_eq!(conn.description.as_ref(), "");
@@ -206,7 +204,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert_eq!(conn.room_number, u16::MAX);
     }
@@ -224,12 +222,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &buffer[1..]);
-        let deserialized = <PktConnection as Parser>::deserialize(packet);
+        let deserialized = PktConnection::decode(packet);
 
         assert_eq!(deserialized.room_number, 7);
         assert_eq!(deserialized.room_name.as_ref(), "Secret Door");
@@ -250,7 +246,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert_eq!(conn.description.len(), 5000);
     }
@@ -268,7 +264,7 @@ mod tests {
         body.extend(&[0xFC, 0xFB]);
 
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert!(conn.room_name.contains('\u{FFFD}'));
         assert!(conn.description.contains('\u{FFFD}'));
@@ -281,7 +277,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x41]; // Need at least 36
         let packet = Packet::new(&stream, PktType::CONNECTION, body);
-        let _ = <PktConnection as Parser>::deserialize(packet);
+        let _ = PktConnection::decode(packet);
     }
 
     /// Empty body should panic.
@@ -291,7 +287,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::CONNECTION, body);
-        let _ = <PktConnection as Parser>::deserialize(packet);
+        let _ = PktConnection::decode(packet);
     }
 
     /// All zeros body.
@@ -300,7 +296,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0x00; 36];
         let packet = Packet::new(&stream, PktType::CONNECTION, &body);
-        let conn = <PktConnection as Parser>::deserialize(packet);
+        let conn = PktConnection::decode(packet);
 
         assert_eq!(conn.room_number, 0);
         assert_eq!(conn.room_name.as_ref(), "");

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -51,7 +51,7 @@ impl PktError {
 /// ```
 macro_rules! send_error {
     ($stream:expr, $pkt_error:expr) => {
-        if let Err(e) = $crate::Protocol::Error($stream, $pkt_error).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_error) {
             eprintln!("Failed to send error packet: {}", e);
         }
     };
@@ -68,7 +68,7 @@ impl std::fmt::Display for PktError {
 }
 
 impl Parser<'_> for PktError {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -84,7 +84,7 @@ impl Parser<'_> for PktError {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_type = packet.packet_type;
         let error = LurkError::from(packet.body[0]);
         let message_len = u16::from_le_bytes([packet.body[1], packet.body[2]]);
@@ -121,7 +121,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktError
-        let message = <PktError as Parser>::deserialize(packet);
+        let message = PktError::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::ERROR);
@@ -131,9 +131,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -169,12 +167,12 @@ mod tests {
         for (i, lurk_err) in errors.iter().enumerate() {
             let err = PktError::new(*lurk_err, "test");
             let mut buffer: Vec<u8> = Vec::new();
-            err.serialize(&mut buffer).expect("Serialization failed");
+            err.write_to(&mut buffer).expect("Encoding failed");
 
             assert_eq!(buffer[1], i as u8); // Error code is sequential from 0
 
             let packet = Packet::new(&stream, PktType::ERROR, &buffer[1..]);
-            let deserialized = <PktError as Parser>::deserialize(packet);
+            let deserialized = PktError::decode(packet);
             assert_eq!(deserialized.error, *lurk_err);
         }
     }
@@ -186,10 +184,10 @@ mod tests {
         let err = PktError::new(LurkError::OTHER, "");
 
         let mut buffer: Vec<u8> = Vec::new();
-        err.serialize(&mut buffer).expect("Serialization failed");
+        err.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::ERROR, &buffer[1..]);
-        let deserialized = <PktError as Parser>::deserialize(packet);
+        let deserialized = PktError::decode(packet);
         assert_eq!(deserialized.message_len, 0);
         assert_eq!(deserialized.message.as_ref(), "");
     }
@@ -202,10 +200,10 @@ mod tests {
         let err = PktError::new(LurkError::OTHER, &long_msg);
 
         let mut buffer: Vec<u8> = Vec::new();
-        err.serialize(&mut buffer).expect("Serialization failed");
+        err.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::ERROR, &buffer[1..]);
-        let deserialized = <PktError as Parser>::deserialize(packet);
+        let deserialized = PktError::decode(packet);
         assert_eq!(deserialized.message.len(), 5000);
     }
 
@@ -219,7 +217,7 @@ mod tests {
         body.extend(b"test");
 
         let packet = Packet::new(&stream, PktType::ERROR, &body);
-        let err = <PktError as Parser>::deserialize(packet);
+        let err = PktError::decode(packet);
         assert_eq!(err.error, LurkError::OTHER);
     }
 
@@ -230,7 +228,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00]; // Need at least 3
         let packet = Packet::new(&stream, PktType::ERROR, body);
-        let _ = <PktError as Parser>::deserialize(packet);
+        let _ = PktError::decode(packet);
     }
 
     /// Empty body should panic.
@@ -240,7 +238,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::ERROR, body);
-        let _ = <PktError as Parser>::deserialize(packet);
+        let _ = PktError::decode(packet);
     }
 
     /// All zeros body should parse.
@@ -249,7 +247,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::ERROR, body);
-        let err = <PktError as Parser>::deserialize(packet);
+        let err = PktError::decode(packet);
 
         assert_eq!(err.error, LurkError::OTHER);
         assert_eq!(err.message_len, 0);
@@ -274,7 +272,7 @@ mod tests {
         body.extend(&[0xFF, 0xFE, 0xFD, 0xFC]);
 
         let packet = Packet::new(&stream, PktType::ERROR, &body);
-        let err = <PktError as Parser>::deserialize(packet);
+        let err = PktError::decode(packet);
         assert!(err.message.contains('\u{FFFD}'));
     }
 }

--- a/src/packet/fight.rs
+++ b/src/packet/fight.rs
@@ -44,7 +44,7 @@ impl Default for PktFight {
 /// ```
 macro_rules! send_fight {
     ($stream:expr, $pkt_fight:expr) => {
-        if let Err(e) = $crate::Protocol::Fight($stream, $pkt_fight).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_fight) {
             eprintln!("Failed to send fight packet: {}", e);
         }
     };
@@ -61,7 +61,7 @@ impl std::fmt::Display for PktFight {
 }
 
 impl Parser<'_> for PktFight {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -73,7 +73,7 @@ impl Parser<'_> for PktFight {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         Self {
             packet_type: packet.packet_type,
         }
@@ -96,16 +96,14 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &[]);
 
         // Deserialize the packet into a PktFight
-        let message = <PktFight as Parser>::deserialize(packet);
+        let message = PktFight::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::FIGHT);
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -124,7 +122,7 @@ mod tests {
     fn fight_serialize_length() {
         let fight = PktFight::default();
         let mut buffer: Vec<u8> = Vec::new();
-        fight.serialize(&mut buffer).expect("Serialization failed");
+        fight.write_to(&mut buffer).expect("Encoding failed");
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer[0], 0x03);
     }
@@ -136,12 +134,10 @@ mod tests {
         let original = PktFight::default();
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::FIGHT, &[]);
-        let deserialized = <PktFight as Parser>::deserialize(packet);
+        let deserialized = PktFight::decode(packet);
         assert_eq!(deserialized.packet_type, PktType::FIGHT);
     }
 
@@ -151,7 +147,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::FIGHT, body);
-        let fight = <PktFight as Parser>::deserialize(packet);
+        let fight = PktFight::decode(packet);
         assert_eq!(fight.packet_type, PktType::FIGHT);
     }
 

--- a/src/packet/game.rs
+++ b/src/packet/game.rs
@@ -46,9 +46,7 @@ pub struct PktGame {
 /// ```
 macro_rules! send_game {
     ($stream:expr, $pkt_game:expr) => {
-        $crate::Protocol::Game($stream, $pkt_game)
-            .send()
-            .expect("Failed to send game packet");
+        $crate::send_to($stream.as_ref(), &$pkt_game).expect("Failed to send game packet");
     };
 }
 
@@ -63,7 +61,7 @@ impl std::fmt::Display for PktGame {
 }
 
 impl Parser<'_> for PktGame {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -80,7 +78,7 @@ impl Parser<'_> for PktGame {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let initial_points = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let stat_limit = u16::from_le_bytes([packet.body[2], packet.body[3]]);
         let description_len = u16::from_le_bytes([packet.body[4], packet.body[5]]);
@@ -115,7 +113,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktGame
-        let message = <PktGame as Parser>::deserialize(packet);
+        let message = PktGame::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::GAME);
@@ -126,9 +124,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -144,7 +140,7 @@ mod tests {
         let mut body: Vec<u8> = vec![0x64, 0x00, 0xFF, 0xFF, 0x0B, 0x00];
         body.extend(b"Hello World");
         let packet = Packet::new(&stream, PktType::GAME, &body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, 100);
         assert_eq!(game.stat_limit, 65535);
@@ -158,7 +154,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x64, 0x00, 0xFF, 0xFF, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, 100);
         assert_eq!(game.stat_limit, 65535);
@@ -172,7 +168,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, u16::MAX);
         assert_eq!(game.stat_limit, u16::MAX);
@@ -184,7 +180,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, 0);
         assert_eq!(game.stat_limit, 0);
@@ -204,12 +200,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::GAME, &buffer[1..]);
-        let deserialized = <PktGame as Parser>::deserialize(packet);
+        let deserialized = PktGame::decode(packet);
 
         assert_eq!(deserialized.initial_points, 200);
         assert_eq!(deserialized.stat_limit, 1000);
@@ -227,7 +221,7 @@ mod tests {
         body.extend(desc_len.to_le_bytes());
         body.extend(desc.as_bytes());
         let packet = Packet::new(&stream, PktType::GAME, &body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.description_len, 5000);
         assert_eq!(game.description.len(), 5000);
@@ -240,7 +234,7 @@ mod tests {
         let mut body: Vec<u8> = vec![0x64, 0x00, 0xFF, 0xFF, 0x04, 0x00];
         body.extend(&[0xFF, 0xFE, 0xFD, 0xFC]); // invalid UTF-8
         let packet = Packet::new(&stream, PktType::GAME, &body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.description_len, 4);
         // Should contain replacement characters
@@ -254,7 +248,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x64, 0x00]; // Only 2 bytes, need at least 6
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let _ = <PktGame as Parser>::deserialize(packet);
+        let _ = PktGame::decode(packet);
     }
 
     /// Empty body should panic.
@@ -264,7 +258,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let _ = <PktGame as Parser>::deserialize(packet);
+        let _ = PktGame::decode(packet);
     }
 
     /// All 0xFF body should parse without panic.
@@ -273,7 +267,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, 65535);
         assert_eq!(game.stat_limit, 65535);
@@ -285,7 +279,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::GAME, body);
-        let game = <PktGame as Parser>::deserialize(packet);
+        let game = PktGame::decode(packet);
 
         assert_eq!(game.initial_points, 0);
         assert_eq!(game.stat_limit, 0);
@@ -323,12 +317,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::GAME, &buffer[1..]);
-        let deserialized = <PktGame as Parser>::deserialize(packet);
+        let deserialized = PktGame::decode(packet);
 
         assert_eq!(deserialized.description.as_ref(), desc);
     }

--- a/src/packet/leave.rs
+++ b/src/packet/leave.rs
@@ -33,7 +33,7 @@ impl Default for PktLeave {
 /// ```
 macro_rules! send_leave {
     ($stream:expr, $pkt_leave:expr) => {
-        if let Err(e) = $crate::Protocol::Leave($stream, $pkt_leave).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_leave) {
             eprintln!("Failed to send leave packet: {}", e);
         }
     };
@@ -50,7 +50,7 @@ impl std::fmt::Display for PktLeave {
 }
 
 impl Parser<'_> for PktLeave {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -62,7 +62,7 @@ impl Parser<'_> for PktLeave {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         Self {
             packet_type: packet.packet_type,
         }
@@ -85,16 +85,14 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &[]);
 
         // Deserialize the packet into a PktLeave
-        let message = <PktLeave as Parser>::deserialize(packet);
+        let message = PktLeave::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::LEAVE);
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -113,7 +111,7 @@ mod tests {
     fn leave_serialize_length() {
         let leave = PktLeave::default();
         let mut buffer: Vec<u8> = Vec::new();
-        leave.serialize(&mut buffer).expect("Serialization failed");
+        leave.write_to(&mut buffer).expect("Encoding failed");
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer[0], 0x0c);
     }
@@ -125,12 +123,10 @@ mod tests {
         let original = PktLeave::default();
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::LEAVE, &[]);
-        let deserialized = <PktLeave as Parser>::deserialize(packet);
+        let deserialized = PktLeave::decode(packet);
         assert_eq!(deserialized.packet_type, PktType::LEAVE);
     }
 
@@ -140,7 +136,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::LEAVE, body);
-        let leave = <PktLeave as Parser>::deserialize(packet);
+        let leave = PktLeave::decode(packet);
         assert_eq!(leave.packet_type, PktType::LEAVE);
     }
 

--- a/src/packet/loot.rs
+++ b/src/packet/loot.rs
@@ -37,7 +37,7 @@ impl PktLoot {
 /// ```
 macro_rules! send_loot {
     ($stream:expr, $pkt_loot:expr) => {
-        if let Err(e) = $crate::Protocol::Loot($stream, $pkt_loot).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_loot) {
             eprintln!("Failed to send loot packet: {}", e);
         }
     };
@@ -54,7 +54,7 @@ impl std::fmt::Display for PktLoot {
 }
 
 impl Parser<'_> for PktLoot {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -70,7 +70,7 @@ impl Parser<'_> for PktLoot {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_type = packet.packet_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .split('\0')
@@ -104,7 +104,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktLoot
-        let message = <PktLoot as Parser>::deserialize(packet);
+        let message = PktLoot::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::LOOT);
@@ -112,9 +112,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -131,7 +129,7 @@ mod tests {
         body.extend(&name);
 
         let packet = Packet::new(&stream, PktType::LOOT, &body);
-        let loot = <PktLoot as Parser>::deserialize(packet);
+        let loot = PktLoot::decode(packet);
 
         assert_eq!(loot.target_name.as_ref(), "Deku Baba");
     }
@@ -150,7 +148,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0x00; 32];
         let packet = Packet::new(&stream, PktType::LOOT, &body);
-        let loot = <PktLoot as Parser>::deserialize(packet);
+        let loot = PktLoot::decode(packet);
 
         assert_eq!(loot.target_name.as_ref(), "");
     }
@@ -162,7 +160,7 @@ mod tests {
         let long_name = "M".repeat(32);
         let body: Vec<u8> = long_name.as_bytes().to_vec();
         let packet = Packet::new(&stream, PktType::LOOT, &body);
-        let loot = <PktLoot as Parser>::deserialize(packet);
+        let loot = PktLoot::decode(packet);
 
         assert_eq!(loot.target_name.as_ref(), &long_name);
     }
@@ -174,14 +172,12 @@ mod tests {
         let original = PktLoot::loot("DragonBoss");
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         assert_eq!(buffer.len(), 33); // type(1) + name(32)
 
         let packet = Packet::new(&stream, PktType::LOOT, &buffer[1..]);
-        let deserialized = <PktLoot as Parser>::deserialize(packet);
+        let deserialized = PktLoot::decode(packet);
         assert_eq!(deserialized.target_name.as_ref(), "DragonBoss");
     }
 
@@ -192,7 +188,7 @@ mod tests {
         let mut body = vec![0xFF, 0xFE, 0xFD];
         body.resize(32, 0x00);
         let packet = Packet::new(&stream, PktType::LOOT, &body);
-        let loot = <PktLoot as Parser>::deserialize(packet);
+        let loot = PktLoot::decode(packet);
 
         assert!(loot.target_name.contains('\u{FFFD}'));
     }
@@ -204,7 +200,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x41, 0x42]; // Only 2 bytes, need 32
         let packet = Packet::new(&stream, PktType::LOOT, body);
-        let _ = <PktLoot as Parser>::deserialize(packet);
+        let _ = PktLoot::decode(packet);
     }
 
     /// Empty body should panic.
@@ -214,7 +210,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::LOOT, body);
-        let _ = <PktLoot as Parser>::deserialize(packet);
+        let _ = PktLoot::decode(packet);
     }
 
     /// All 0xFF body.
@@ -223,7 +219,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0xFF; 32];
         let packet = Packet::new(&stream, PktType::LOOT, &body);
-        let loot = <PktLoot as Parser>::deserialize(packet);
+        let loot = PktLoot::decode(packet);
 
         assert!(!loot.target_name.is_empty());
     }

--- a/src/packet/message.rs
+++ b/src/packet/message.rs
@@ -77,7 +77,7 @@ impl PktMessage {
 /// ```
 macro_rules! send_message {
     ($stream:expr, $msg:expr) => {
-        if let Err(e) = $crate::Protocol::Message($stream, $msg).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$msg) {
             eprintln!("Failed to send message packet: {}", e);
         }
     };
@@ -95,7 +95,7 @@ impl std::fmt::Display for PktMessage {
 }
 
 impl Parser<'_> for PktMessage {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -128,7 +128,7 @@ impl Parser<'_> for PktMessage {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_len = u16::from_le_bytes([packet.body[0], packet.body[1]]);
 
         // Process the names for recipient and sender
@@ -188,7 +188,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktMessage
-        let message = <PktMessage as Parser>::deserialize(packet);
+        let message = PktMessage::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::MESSAGE);
@@ -200,9 +200,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -224,7 +222,7 @@ mod tests {
         body.extend(b"Sup");
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &body);
-        let msg = <PktMessage as Parser>::deserialize(packet);
+        let msg = PktMessage::decode(packet);
 
         assert_eq!(msg.message_len, 3);
         assert_eq!(msg.recipient.as_ref(), "Player1");
@@ -249,7 +247,7 @@ mod tests {
         body.extend(msg_text.as_bytes());
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &body);
-        let msg = <PktMessage as Parser>::deserialize(packet);
+        let msg = PktMessage::decode(packet);
 
         assert_eq!(msg.recipient.as_ref(), "Player1");
         assert_eq!(msg.sender.as_ref(), "Server");
@@ -287,7 +285,7 @@ mod tests {
         let msg = PktMessage::narrator("Player1", "A tale of old.");
 
         let mut buffer: Vec<u8> = Vec::new();
-        msg.serialize(&mut buffer).expect("Serialization failed");
+        msg.write_to(&mut buffer).expect("Encoding failed");
 
         // Check the narration marker bytes at end of sender field (bytes 35..67, sender is at 35+30=65,66)
         // Sender occupies bytes 35..67 in the full packet (including type byte at 0)
@@ -298,7 +296,7 @@ mod tests {
 
         // Deserialize and verify
         let packet = Packet::new(&stream, PktType::MESSAGE, &buffer[1..]);
-        let deserialized = <PktMessage as Parser>::deserialize(packet);
+        let deserialized = PktMessage::decode(packet);
         assert!(deserialized.narration);
         assert_eq!(deserialized.sender.as_ref(), "Narrator");
     }
@@ -310,10 +308,10 @@ mod tests {
         let msg = PktMessage::server("Player1", "Hello.");
 
         let mut buffer: Vec<u8> = Vec::new();
-        msg.serialize(&mut buffer).expect("Serialization failed");
+        msg.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &buffer[1..]);
-        let deserialized = <PktMessage as Parser>::deserialize(packet);
+        let deserialized = PktMessage::decode(packet);
         assert!(!deserialized.narration);
         assert_eq!(deserialized.sender.as_ref(), "Server");
         assert_eq!(deserialized.message.as_ref(), "Hello.");
@@ -326,10 +324,10 @@ mod tests {
         let msg = PktMessage::server("Player1", "");
 
         let mut buffer: Vec<u8> = Vec::new();
-        msg.serialize(&mut buffer).expect("Serialization failed");
+        msg.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &buffer[1..]);
-        let deserialized = <PktMessage as Parser>::deserialize(packet);
+        let deserialized = PktMessage::decode(packet);
         assert_eq!(deserialized.message_len, 0);
         assert_eq!(deserialized.message.as_ref(), "");
     }
@@ -342,10 +340,10 @@ mod tests {
         let msg = PktMessage::server("Player1", &long_text);
 
         let mut buffer: Vec<u8> = Vec::new();
-        msg.serialize(&mut buffer).expect("Serialization failed");
+        msg.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &buffer[1..]);
-        let deserialized = <PktMessage as Parser>::deserialize(packet);
+        let deserialized = PktMessage::decode(packet);
         assert_eq!(deserialized.message_len, 5000);
         assert_eq!(deserialized.message.len(), 5000);
     }
@@ -365,10 +363,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        msg.serialize(&mut buffer).expect("Serialization failed");
+        msg.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &buffer[1..]);
-        let deserialized = <PktMessage as Parser>::deserialize(packet);
+        let deserialized = PktMessage::decode(packet);
         assert_eq!(deserialized.recipient.as_ref(), &long_name);
     }
 
@@ -379,7 +377,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x41]; // Only 3 bytes, need at least 66
         let packet = Packet::new(&stream, PktType::MESSAGE, body);
-        let _ = <PktMessage as Parser>::deserialize(packet);
+        let _ = PktMessage::decode(packet);
     }
 
     /// Empty body should panic.
@@ -389,7 +387,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::MESSAGE, body);
-        let _ = <PktMessage as Parser>::deserialize(packet);
+        let _ = PktMessage::decode(packet);
     }
 
     /// All-zero 66-byte body should parse without panic.
@@ -398,7 +396,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0x00; 66];
         let packet = Packet::new(&stream, PktType::MESSAGE, &body);
-        let msg = <PktMessage as Parser>::deserialize(packet);
+        let msg = PktMessage::decode(packet);
 
         assert_eq!(msg.message_len, 0);
         assert_eq!(msg.recipient.as_ref(), "");
@@ -412,7 +410,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0xFF; 66];
         let packet = Packet::new(&stream, PktType::MESSAGE, &body);
-        let msg = <PktMessage as Parser>::deserialize(packet);
+        let msg = PktMessage::decode(packet);
 
         assert_eq!(msg.message_len, u16::MAX);
         // Recipient and sender will contain replacement chars for invalid UTF-8
@@ -434,7 +432,7 @@ mod tests {
         body.extend(&sender);
 
         let packet = Packet::new(&stream, PktType::MESSAGE, &body);
-        let msg = <PktMessage as Parser>::deserialize(packet);
+        let msg = PktMessage::decode(packet);
 
         assert!(msg.recipient.contains('\u{FFFD}'));
         assert!(msg.sender.contains('\u{FFFD}'));

--- a/src/packet/pvp_fight.rs
+++ b/src/packet/pvp_fight.rs
@@ -44,7 +44,7 @@ impl PktPVPFight {
 /// ```
 macro_rules! send_pvp {
     ($stream:expr, $pkt_pvp:expr) => {
-        if let Err(e) = $crate::Protocol::PVPFight($stream, $pkt_pvp).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_pvp) {
             eprintln!("Failed to send pvp fight packet: {}", e);
         }
     };
@@ -62,7 +62,7 @@ impl std::fmt::Display for PktPVPFight {
 }
 
 impl Parser<'_> for PktPVPFight {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -78,7 +78,7 @@ impl Parser<'_> for PktPVPFight {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_type = packet.packet_type;
         let target_name = String::from_utf8_lossy(&packet.body[0..32])
             .split('\0')
@@ -112,7 +112,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktPVPFight
-        let message = <PktPVPFight as Parser>::deserialize(packet);
+        let message = PktPVPFight::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::PVPFIGHT);
@@ -120,9 +120,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -143,7 +141,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0x00; 32];
         let packet = Packet::new(&stream, PktType::PVPFIGHT, &body);
-        let pvp = <PktPVPFight as Parser>::deserialize(packet);
+        let pvp = PktPVPFight::decode(packet);
 
         assert_eq!(pvp.target_name.as_ref(), "");
     }
@@ -155,7 +153,7 @@ mod tests {
         let long_name = "P".repeat(32);
         let body: Vec<u8> = long_name.as_bytes().to_vec();
         let packet = Packet::new(&stream, PktType::PVPFIGHT, &body);
-        let pvp = <PktPVPFight as Parser>::deserialize(packet);
+        let pvp = PktPVPFight::decode(packet);
 
         assert_eq!(pvp.target_name.as_ref(), &long_name);
     }
@@ -167,14 +165,12 @@ mod tests {
         let original = PktPVPFight::fight("Rival");
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         assert_eq!(buffer.len(), 33); // type(1) + name(32)
 
         let packet = Packet::new(&stream, PktType::PVPFIGHT, &buffer[1..]);
-        let deserialized = <PktPVPFight as Parser>::deserialize(packet);
+        let deserialized = PktPVPFight::decode(packet);
         assert_eq!(deserialized.target_name.as_ref(), "Rival");
     }
 
@@ -185,7 +181,7 @@ mod tests {
         let mut body = vec![0xFF, 0xFE, 0xFD];
         body.resize(32, 0x00);
         let packet = Packet::new(&stream, PktType::PVPFIGHT, &body);
-        let pvp = <PktPVPFight as Parser>::deserialize(packet);
+        let pvp = PktPVPFight::decode(packet);
 
         assert!(pvp.target_name.contains('\u{FFFD}'));
     }
@@ -197,7 +193,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x41, 0x42]; // Only 2 bytes, need 32
         let packet = Packet::new(&stream, PktType::PVPFIGHT, body);
-        let _ = <PktPVPFight as Parser>::deserialize(packet);
+        let _ = PktPVPFight::decode(packet);
     }
 
     /// Empty body should panic.
@@ -207,7 +203,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::PVPFIGHT, body);
-        let _ = <PktPVPFight as Parser>::deserialize(packet);
+        let _ = PktPVPFight::decode(packet);
     }
 
     /// All 0xFF body.
@@ -216,7 +212,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0xFF; 32];
         let packet = Packet::new(&stream, PktType::PVPFIGHT, &body);
-        let pvp = <PktPVPFight as Parser>::deserialize(packet);
+        let pvp = PktPVPFight::decode(packet);
 
         assert!(!pvp.target_name.is_empty());
     }

--- a/src/packet/room.rs
+++ b/src/packet/room.rs
@@ -45,7 +45,7 @@ pub struct PktRoom {
 /// ```
 macro_rules! send_room {
     ($stream:expr, $room:expr) => {
-        if let Err(e) = $crate::Protocol::Room($stream, $room).send() {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$room) {
             eprintln!("Failed to send room packet: {}", e);
         }
     };
@@ -62,7 +62,7 @@ impl std::fmt::Display for PktRoom {
 }
 
 impl Parser<'_> for PktRoom {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -83,7 +83,7 @@ impl Parser<'_> for PktRoom {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         let message_type = packet.packet_type;
         let room_number = u16::from_le_bytes([packet.body[0], packet.body[1]]);
         let room_name = String::from_utf8_lossy(&packet.body[2..34])
@@ -125,7 +125,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktRoom
-        let message = <PktRoom as Parser>::deserialize(packet);
+        let message = PktRoom::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::ROOM);
@@ -139,9 +139,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -163,7 +161,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.room_number, 0);
         assert_eq!(room.room_name.as_ref(), room_name);
@@ -182,7 +180,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.room_number, 5);
         assert_eq!(room.room_name.as_ref(), "Empty");
@@ -202,7 +200,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.room_number, u16::MAX);
     }
@@ -218,7 +216,7 @@ mod tests {
         body.extend(0u16.to_le_bytes());
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.room_name.as_ref(), &long_name);
     }
@@ -236,12 +234,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::ROOM, &buffer[1..]);
-        let deserialized = <PktRoom as Parser>::deserialize(packet);
+        let deserialized = PktRoom::decode(packet);
 
         assert_eq!(deserialized.room_number, 42);
         assert_eq!(deserialized.room_name.as_ref(), "Treasure Room");
@@ -262,7 +258,7 @@ mod tests {
         body.extend(desc.as_bytes());
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.description.len(), 5000);
     }
@@ -280,7 +276,7 @@ mod tests {
         body.extend(&[0xFC, 0xFB, 0xFA]);
 
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert!(room.room_name.contains('\u{FFFD}'));
         assert!(room.description.contains('\u{FFFD}'));
@@ -293,7 +289,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00]; // Need at least 36
         let packet = Packet::new(&stream, PktType::ROOM, body);
-        let _ = <PktRoom as Parser>::deserialize(packet);
+        let _ = PktRoom::decode(packet);
     }
 
     /// Empty body should panic.
@@ -303,7 +299,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::ROOM, body);
-        let _ = <PktRoom as Parser>::deserialize(packet);
+        let _ = PktRoom::decode(packet);
     }
 
     /// All zeros body (36 bytes min header).
@@ -312,7 +308,7 @@ mod tests {
         let stream = test_common::setup();
         let body: Vec<u8> = vec![0x00; 36];
         let packet = Packet::new(&stream, PktType::ROOM, &body);
-        let room = <PktRoom as Parser>::deserialize(packet);
+        let room = PktRoom::decode(packet);
 
         assert_eq!(room.room_number, 0);
         assert_eq!(room.room_name.as_ref(), "");

--- a/src/packet/start.rs
+++ b/src/packet/start.rs
@@ -37,8 +37,8 @@ impl Default for PktStart {
 /// send_start!(stream.clone(), PktStart::default())
 /// ```
 macro_rules! send_start {
-    ($stream:expr, $pkt_fight:expr) => {
-        if let Err(e) = $crate::Protocol::Start($stream, $pkt_fight).send() {
+    ($stream:expr, $pkt_start:expr) => {
+        if let Err(e) = $crate::send_to($stream.as_ref(), &$pkt_start) {
             eprintln!("Failed to send start packet: {}", e);
         }
     };
@@ -55,7 +55,7 @@ impl std::fmt::Display for PktStart {
 }
 
 impl Parser<'_> for PktStart {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -67,7 +67,7 @@ impl Parser<'_> for PktStart {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         Self {
             packet_type: packet.packet_type,
         }
@@ -89,16 +89,14 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktStart
-        let message = <PktStart as Parser>::deserialize(packet);
+        let message = PktStart::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::START);
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -117,7 +115,7 @@ mod tests {
     fn start_serialize_length() {
         let start = PktStart::default();
         let mut buffer: Vec<u8> = Vec::new();
-        start.serialize(&mut buffer).expect("Serialization failed");
+        start.write_to(&mut buffer).expect("Encoding failed");
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer[0], 0x06);
     }
@@ -129,12 +127,10 @@ mod tests {
         let original = PktStart::default();
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::START, &[]);
-        let deserialized = <PktStart as Parser>::deserialize(packet);
+        let deserialized = PktStart::decode(packet);
         assert_eq!(deserialized.packet_type, PktType::START);
     }
 
@@ -144,7 +140,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::START, body);
-        let start = <PktStart as Parser>::deserialize(packet);
+        let start = PktStart::decode(packet);
         assert_eq!(start.packet_type, PktType::START);
     }
 

--- a/src/packet/version.rs
+++ b/src/packet/version.rs
@@ -46,9 +46,7 @@ pub struct PktVersion {
 /// ```
 macro_rules! send_version {
     ($stream:expr, $pkt_version:expr) => {
-        $crate::Protocol::Version($stream, $pkt_version)
-            .send()
-            .expect("Failed to send version packet");
+        $crate::send_to($stream.as_ref(), &$pkt_version).expect("Failed to send version packet");
     };
 }
 
@@ -64,7 +62,7 @@ impl std::fmt::Display for PktVersion {
 }
 
 impl Parser<'_> for PktVersion {
-    fn serialize<W: Write>(self, writer: &mut W) -> Result<(), std::io::Error> {
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // Package into a byte array
         let mut packet: Vec<u8> = vec![self.packet_type.into()];
 
@@ -84,7 +82,7 @@ impl Parser<'_> for PktVersion {
         Ok(())
     }
 
-    fn deserialize(packet: Packet) -> Self {
+    fn decode(packet: Packet) -> Self {
         Self {
             packet_type: packet.packet_type,
             major_rev: packet.body[0],
@@ -111,7 +109,7 @@ mod tests {
         let packet = Packet::new(&stream, type_byte, &original_bytes[1..]);
 
         // Deserialize the packet into a PktVersion
-        let message = <PktVersion as Parser>::deserialize(packet);
+        let message = PktVersion::decode(packet);
 
         // Assert the fields were parsed correctly
         assert_eq!(message.packet_type, PktType::VERSION);
@@ -122,9 +120,7 @@ mod tests {
 
         // Serialize the message back into bytes
         let mut buffer: Vec<u8> = Vec::new();
-        message
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        message.write_to(&mut buffer).expect("Encoding failed");
 
         // Assert that the serialized bytes match the original
         assert_eq!(buffer, original_bytes);
@@ -138,7 +134,7 @@ mod tests {
         // From trace: 0e 02 03 00 00
         let body: &[u8] = &[0x02, 0x03, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 2);
         assert_eq!(ver.minor_rev, 3);
@@ -152,7 +148,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 255);
         assert_eq!(ver.minor_rev, 255);
@@ -164,7 +160,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 0);
         assert_eq!(ver.minor_rev, 0);
@@ -182,7 +178,7 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        ver.serialize(&mut buffer).expect("Serialization failed");
+        ver.write_to(&mut buffer).expect("Encoding failed");
 
         // Type(1) + major(1) + minor(1) + ext_len(2) + extensions(5) = 10
         assert_eq!(buffer.len(), 10);
@@ -206,7 +202,7 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        ver.serialize(&mut buffer).expect("Serialization failed");
+        ver.write_to(&mut buffer).expect("Encoding failed");
 
         assert_eq!(buffer.len(), 5);
         assert_eq!(buffer, &[0x0e, 0x01, 0x00, 0x00, 0x00]);
@@ -225,12 +221,10 @@ mod tests {
         };
 
         let mut buffer: Vec<u8> = Vec::new();
-        original
-            .serialize(&mut buffer)
-            .expect("Serialization failed");
+        original.write_to(&mut buffer).expect("Encoding failed");
 
         let packet = Packet::new(&stream, PktType::VERSION, &buffer[1..]);
-        let deserialized = <PktVersion as Parser>::deserialize(packet);
+        let deserialized = PktVersion::decode(packet);
 
         assert_eq!(deserialized.major_rev, 10);
         assert_eq!(deserialized.minor_rev, 42);
@@ -242,7 +236,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x02, 0x03, 0x00, 0x00, 0xFF, 0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 2);
         assert_eq!(ver.minor_rev, 3);
@@ -255,7 +249,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x02]; // Only 1 byte, need at least 2
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let _ = <PktVersion as Parser>::deserialize(packet);
+        let _ = PktVersion::decode(packet);
     }
 
     /// Empty body should panic during deserialization.
@@ -265,7 +259,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let _ = <PktVersion as Parser>::deserialize(packet);
+        let _ = PktVersion::decode(packet);
     }
 
     /// All 0xFF bytes in body.
@@ -274,7 +268,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 255);
         assert_eq!(ver.minor_rev, 255);
@@ -286,7 +280,7 @@ mod tests {
         let stream = test_common::setup();
         let body: &[u8] = &[0x00, 0x00, 0x00, 0x00];
         let packet = Packet::new(&stream, PktType::VERSION, body);
-        let ver = <PktVersion as Parser>::deserialize(packet);
+        let ver = PktVersion::decode(packet);
 
         assert_eq!(ver.major_rev, 0);
         assert_eq!(ver.minor_rev, 0);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -139,7 +139,7 @@ impl Protocol {
     /// // Send the packet to connected user
     /// Protocol::Message(stream.clone(), pkt_message).send().unwrap();
     /// ```
-    pub fn send(self) -> Result<(), std::io::Error> {
+    pub fn send(&self) -> Result<(), std::io::Error> {
         let mut byte_stream: Vec<u8> = Vec::new();
 
         #[cfg(feature = "tracing")]
@@ -148,59 +148,59 @@ impl Protocol {
         // Serialize the packet and send it to the server
         let author = match self {
             Protocol::Message(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::ChangeRoom(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Fight(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::PVPFight(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Loot(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Start(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Error(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Accept(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Room(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Character(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Game(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Leave(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Connection(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
             Protocol::Version(author, content) => {
-                content.serialize(&mut byte_stream)?;
+                content.write_to(&mut byte_stream)?;
                 author
             }
         };
@@ -257,10 +257,7 @@ impl Protocol {
 
                 let pkt = Packet::read_extended(stream, packet_type, &mut buffer, (0, 1))?;
 
-                Ok(Protocol::Message(
-                    stream.clone(),
-                    PktMessage::deserialize(pkt),
-                ))
+                Ok(Protocol::Message(stream.clone(), PktMessage::decode(pkt)))
             }
             PktType::CHANGEROOM => {
                 let mut buffer = vec![0; 2];
@@ -269,7 +266,7 @@ impl Protocol {
 
                 Ok(Protocol::ChangeRoom(
                     stream.clone(),
-                    PktChangeRoom::deserialize(packet),
+                    PktChangeRoom::decode(packet),
                 ))
             }
             PktType::FIGHT => Ok(Protocol::Fight(stream.clone(), PktFight::default())),
@@ -280,7 +277,7 @@ impl Protocol {
 
                 Ok(Protocol::PVPFight(
                     stream.clone(),
-                    PktPVPFight::deserialize(packet),
+                    PktPVPFight::decode(packet),
                 ))
             }
             PktType::LOOT => {
@@ -288,7 +285,7 @@ impl Protocol {
 
                 let packet = Packet::read_into(stream, packet_type, &mut buffer)?;
 
-                Ok(Protocol::Loot(stream.clone(), PktLoot::deserialize(packet)))
+                Ok(Protocol::Loot(stream.clone(), PktLoot::decode(packet)))
             }
             PktType::START => Ok(Protocol::Start(stream.clone(), PktStart::default())),
             PktType::ERROR => {
@@ -296,27 +293,21 @@ impl Protocol {
 
                 let packet = Packet::read_extended(stream, packet_type, &mut buffer, (1, 2))?;
 
-                Ok(Protocol::Error(
-                    stream.clone(),
-                    PktError::deserialize(packet),
-                ))
+                Ok(Protocol::Error(stream.clone(), PktError::decode(packet)))
             }
             PktType::ACCEPT => {
                 let mut buffer = vec![0; 1];
 
                 let packet = Packet::read_into(stream, packet_type, &mut buffer)?;
 
-                Ok(Protocol::Accept(
-                    stream.clone(),
-                    PktAccept::deserialize(packet),
-                ))
+                Ok(Protocol::Accept(stream.clone(), PktAccept::decode(packet)))
             }
             PktType::ROOM => {
                 let mut buffer = vec![0; 36];
 
                 let packet = Packet::read_extended(stream, packet_type, &mut buffer, (34, 35))?;
 
-                Ok(Protocol::Room(stream.clone(), PktRoom::deserialize(packet)))
+                Ok(Protocol::Room(stream.clone(), PktRoom::decode(packet)))
             }
             PktType::CHARACTER => {
                 let mut buffer = vec![0; 47];
@@ -325,7 +316,7 @@ impl Protocol {
 
                 Ok(Protocol::Character(
                     stream.clone(),
-                    PktCharacter::deserialize(packet),
+                    PktCharacter::decode(packet),
                 ))
             }
             PktType::GAME => {
@@ -333,7 +324,7 @@ impl Protocol {
 
                 let packet = Packet::read_extended(stream, packet_type, &mut buffer, (4, 5))?;
 
-                Ok(Protocol::Game(stream.clone(), PktGame::deserialize(packet)))
+                Ok(Protocol::Game(stream.clone(), PktGame::decode(packet)))
             }
             PktType::LEAVE => Ok(Protocol::Leave(stream.clone(), PktLeave::default())),
             PktType::CONNECTION => {
@@ -343,7 +334,7 @@ impl Protocol {
 
                 Ok(Protocol::Connection(
                     stream.clone(),
-                    PktConnection::deserialize(packet),
+                    PktConnection::decode(packet),
                 ))
             }
             PktType::VERSION => {
@@ -353,7 +344,7 @@ impl Protocol {
 
                 Ok(Protocol::Version(
                     stream.clone(),
-                    PktVersion::deserialize(packet),
+                    PktVersion::decode(packet),
                 ))
             }
             PktType::DEFAULT => Err(Error::new(ErrorKind::Unsupported, "Invalid packet type")),


### PR DESCRIPTION
- Added a helper `send_to` function to `lib.rs` so `Protocol` doesn't need to take ownership over a packet.
- Renamed `serialize` and `deserialize` to:
  - `write_to`
  - `decode`
- Updated documentation and tests