### PR TITLE
Rename to `lurk_protocol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lurk_lcsc"
+name = "lurk_protocol"
 version = "2.3.21"
 dependencies = [
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "lurk_lcsc"
-version = "2.3.21"
+name = "lurk_protocol"
+version = "2.3.0"
 authors = ["Riley Ziegler", "S. Seth Long, Ph.D"]
 categories = ["network-programming"]
-description = "LCSC LURK Protocol written in Rust"
-documentation = "https://docs.rs/lurk-lcsc"
+description = "LURK Protocol written in Rust"
+documentation = "https://docs.rs/lurk_protocol"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/The24Kings/lurk_lcsc"
+repository = "https://github.com/The24Kings/lurk_protocol"
 rust-version = "1.85"
 
 [dependencies]
-bitflags = { version = "2.11.0", features = ["serde"] }
+bitflags = { version = "2.11.1", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"
 tabled = { version = "0.20.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lurk_lcsc
+# lurk_protocol
 
 A Rust library for building **Lurk protocol** servers and clients.  
 This crate implements the [Lurk Protocol](https://github.com/The24Kings/LurkProtocol/wiki), enabling MUD text-based MMORPG games over the network.
@@ -20,9 +20,9 @@ This crate implements the [Lurk Protocol](https://github.com/The24Kings/LurkProt
 
 ## Installation
 
-Add `lurk_lcsc` to your `Cargo.toml`:
+Add `lurk_protocol` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lurk_lcsc = { version = "2.3.21" }
+lurk_protocol = { version = "2.3.0" }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # Lurk LCSC Protocol
+//! # Lurk Protocol
 //!
 //! A lightweight Rust implementation of the **Lurk** protocol created by S. Seth Long, Ph.D.
 //! It provides the fundamental logic for building multiplayer game servers that communicate using the Lurk protocol.
@@ -26,7 +26,7 @@
 //! ### Server Example
 //!
 //! ```no_run
-//! use lurk_lcsc::Protocol;
+//! use lurk_protocol::Protocol;
 //! use std::net::TcpStream;
 //! use std::sync::Arc;
 //!
@@ -55,7 +55,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Lurk types in rustdoc of other crates get linked to here.
-#![doc(html_root_url = "https://docs.rs/lurk_lcsc/2.3.21")]
+#![doc(html_root_url = "https://docs.rs/lurk_protocol/2.3.0")]
 // Show which crate feature enables conditionally compiled APIs in documentation.
 #![cfg_attr(docsrs, feature(doc_cfg, rustdoc_internals))]
 #![cfg_attr(docsrs, allow(internal_features))]
@@ -139,7 +139,7 @@ pub mod packet;
 /// Packet capture and tracing utilities.
 ///
 /// ```no_run
-/// use lurk_lcsc::{PktMessage, Parser, PCap};
+/// use lurk_protocol::{PktMessage, Parser, PCap};
 /// use std::net::TcpStream;
 /// use std::sync::Arc;
 ///

--- a/src/lurk_error.rs
+++ b/src/lurk_error.rs
@@ -28,7 +28,7 @@ impl From<LurkError> for u8 {
     /// Converts a `LurkError` enum variant into its corresponding `u8` value.
     ///     
     /// ```rust
-    /// use lurk_lcsc::lurk_error::LurkError;
+    /// use lurk_protocol::lurk_error::LurkError;
     ///
     /// let err = LurkError::BADROOM;
     /// let err_u8: u8 = err.into();
@@ -43,7 +43,7 @@ impl From<u8> for LurkError {
     /// Converts a `u8` value into its corresponding `LurkError` enum variant.
     ///
     /// ```rust
-    /// use lurk_lcsc::lurk_error::LurkError;
+    /// use lurk_protocol::lurk_error::LurkError;
     ///
     /// let err = LurkError::from(1u8);
     /// assert_eq!(err, LurkError::BADROOM);
@@ -67,7 +67,7 @@ impl std::fmt::Display for LurkError {
     /// Formats the `LurkError` enum variant as a human-readable string.
     ///
     /// ```rust
-    /// use lurk_lcsc::lurk_error::LurkError;
+    /// use lurk_protocol::lurk_error::LurkError;
     /// let err = LurkError::BADROOM;
     /// assert_eq!(format!("{}", err), "BadRoom");
     /// ```

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -46,7 +46,7 @@ pub mod version;
 /// Trait for serializing and deserializing packets.
 ///
 /// ```no_run
-/// use lurk_lcsc::{Packet, Parser, PktType};
+/// use lurk_protocol::{Packet, Parser, PktType};
 /// use std::io::{Error, Write};
 /// use serde::{Deserialize, Serialize};
 ///
@@ -90,8 +90,8 @@ pub trait Parser<'a>: Sized + 'a {
     /// Serializes the packet and writes it to the provided writer.
     ///
     /// ```no_run
-    /// use lurk_lcsc::{Parser, PktType};
-    /// use lurk_lcsc::PktVersion;
+    /// use lurk_protocol::{Parser, PktType};
+    /// use lurk_protocol::PktVersion;
     /// use std::io::Write;
     ///
     /// let packet = PktVersion {
@@ -110,7 +110,7 @@ pub trait Parser<'a>: Sized + 'a {
     /// Deserializes a Packet into the implementing type.
     ///
     /// ```no_run
-    /// use lurk_lcsc::{Protocol, PktType, PktMessage, Packet, Parser};
+    /// use lurk_protocol::{Protocol, PktType, PktMessage, Packet, Parser};
     /// use std::io::{Read, Error, ErrorKind};
     /// use std::sync::Arc;
     /// use std::net::TcpStream;

--- a/src/packet/accept.rs
+++ b/src/packet/accept.rs
@@ -29,7 +29,7 @@ impl PktAccept {
 /// Send `PktAccept` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktType, send_accept};
+/// use lurk_protocol::{Protocol, PktType, send_accept};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/change_room.rs
+++ b/src/packet/change_room.rs
@@ -37,7 +37,7 @@ impl From<PktChangeRoom> for u16 {
 /// Send `PktChangeRoom` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktChangeRoom, LurkError, send_change_room};
+/// use lurk_protocol::{Protocol, PktChangeRoom, LurkError, send_change_room};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/character.rs
+++ b/src/packet/character.rs
@@ -60,7 +60,7 @@ impl PktCharacter {
 /// Send `PktCharacter` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{
+/// use lurk_protocol::{
 ///     Protocol, PktCharacter, LurkError,
 ///     PktType, send_character, CharacterFlags,
 /// };

--- a/src/packet/connection.rs
+++ b/src/packet/connection.rs
@@ -32,7 +32,7 @@ pub struct PktConnection {
 /// Send `PktConnection` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktConnection, PktType, send_connection};
+/// use lurk_protocol::{Protocol, PktConnection, PktType, send_connection};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -41,7 +41,7 @@ impl PktError {
 /// Send `PktError` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktError, LurkError, send_error};
+/// use lurk_protocol::{Protocol, PktError, LurkError, send_error};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/fight.rs
+++ b/src/packet/fight.rs
@@ -34,7 +34,7 @@ impl Default for PktFight {
 /// Send `PktFight` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktFight, LurkError, send_fight};
+/// use lurk_protocol::{Protocol, PktFight, LurkError, send_fight};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/game.rs
+++ b/src/packet/game.rs
@@ -29,7 +29,7 @@ pub struct PktGame {
 /// Send `PktGame` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktGame, PktType, send_game};
+/// use lurk_protocol::{Protocol, PktGame, PktType, send_game};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/leave.rs
+++ b/src/packet/leave.rs
@@ -23,7 +23,7 @@ impl Default for PktLeave {
 /// Send `PktLeave` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktLeave, LurkError, send_leave};
+/// use lurk_protocol::{Protocol, PktLeave, LurkError, send_leave};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/loot.rs
+++ b/src/packet/loot.rs
@@ -27,7 +27,7 @@ impl PktLoot {
 /// Send `PktLoot` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktLoot, LurkError, send_loot};
+/// use lurk_protocol::{Protocol, PktLoot, LurkError, send_loot};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/message.rs
+++ b/src/packet/message.rs
@@ -72,7 +72,7 @@ impl PktMessage {
 /// Send `PktMessage` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktMessage, PktType, send_message};
+/// use lurk_protocol::{Protocol, PktMessage, PktType, send_message};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/pvp_fight.rs
+++ b/src/packet/pvp_fight.rs
@@ -34,7 +34,7 @@ impl PktPVPFight {
 /// Send `PktPVPFight` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktPVPFight, LurkError, send_pvp};
+/// use lurk_protocol::{Protocol, PktPVPFight, LurkError, send_pvp};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/room.rs
+++ b/src/packet/room.rs
@@ -28,7 +28,7 @@ pub struct PktRoom {
 /// Send `PktRoom` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktRoom, PktType, send_room};
+/// use lurk_protocol::{Protocol, PktRoom, PktType, send_room};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/start.rs
+++ b/src/packet/start.rs
@@ -28,7 +28,7 @@ impl Default for PktStart {
 /// Send `PktStart` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktStart, LurkError, send_start};
+/// use lurk_protocol::{Protocol, PktStart, LurkError, send_start};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/packet/version.rs
+++ b/src/packet/version.rs
@@ -29,7 +29,7 @@ pub struct PktVersion {
 /// Send `PktVersion` over `TcpStream` to connected user
 ///
 /// ```no_run
-/// use lurk_lcsc::{Protocol, PktVersion, PktType, send_version};
+/// use lurk_protocol::{Protocol, PktVersion, PktType, send_version};
 /// use std::sync::Arc;
 /// use std::net::TcpStream;
 ///

--- a/src/pcap.rs
+++ b/src/pcap.rs
@@ -53,7 +53,7 @@ impl PCap {
     /// Builds a formatted string representation of the provided byte vector.
     ///
     /// ```no_run
-    /// use lurk_lcsc::pcap::PCap;
+    /// use lurk_protocol::pcap::PCap;
     ///
     /// let data = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21]; // "Hello, World!"
     /// let formatted = PCap::build(data);

--- a/src/pkt_type.rs
+++ b/src/pkt_type.rs
@@ -41,7 +41,7 @@ impl From<PktType> for u8 {
     /// Converts a `PktType` enum variant into its corresponding `u8` value.
     ///
     /// ```rust
-    /// use lurk_lcsc::pkt_type::PktType;
+    /// use lurk_protocol::pkt_type::PktType;
     ///
     /// let pkt = PktType::MESSAGE;
     /// let pkt_u8: u8 = pkt.into();
@@ -59,7 +59,7 @@ impl From<u8> for PktType {
     /// Converts a `u8` value into its corresponding `PktType` enum variant.
     ///
     /// ```rust
-    /// use lurk_lcsc::pkt_type::PktType;
+    /// use lurk_protocol::pkt_type::PktType;
     ///
     /// let pkt_type = PktType::from(3u8);
     /// assert_eq!(pkt_type, PktType::FIGHT);
@@ -89,7 +89,7 @@ impl From<&[u8; 1]> for PktType {
     /// Converts a byte slice into its corresponding `PktType` enum variant.
     ///
     /// ```rust
-    /// use lurk_lcsc::pkt_type::PktType;
+    /// use lurk_protocol::pkt_type::PktType;
     ///
     /// let bytes = [3u8; 1];
     /// let pkt_type = PktType::from(&bytes);
@@ -120,7 +120,7 @@ impl std::fmt::Display for PktType {
     /// Formats the `PktType` enum variant as a human-readable string.
     /// # Example
     /// ```rust
-    /// use lurk_lcsc::pkt_type::PktType;
+    /// use lurk_protocol::pkt_type::PktType;
     ///
     /// let pkt = PktType::FIGHT;
     /// assert_eq!(format!("{}", pkt), "Fight");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,7 +40,7 @@ pub enum Protocol {
     /// Must be sent __second__ on new connections.
     ///
     /// ```
-    /// use lurk_lcsc::{Protocol, PktGame, PktType};
+    /// use lurk_protocol::{Protocol, PktGame, PktType};
     ///
     /// let protocol = Protocol::Game(
     ///     PktGame {
@@ -61,7 +61,7 @@ pub enum Protocol {
     /// Must be sent __first__ on new connections.
     ///
     /// ```
-    /// use lurk_lcsc::{Protocol, PktVersion, PktType};
+    /// use lurk_protocol::{Protocol, PktVersion, PktType};
     ///
     /// let protocol = Protocol::Version(
     ///     PktVersion {
@@ -80,7 +80,7 @@ impl std::fmt::Display for Protocol {
     /// Formats the `Protocol` enum variant as a human-readable string.
     ///
     /// ```
-    /// use lurk_lcsc::{Protocol, PktMessage};
+    /// use lurk_protocol::{Protocol, PktMessage};
     ///
     /// let pkt_message = PktMessage::server("Recipient", "Hello, server!");
     /// let protocol = Protocol::Message(pkt_message);
@@ -111,7 +111,7 @@ impl Protocol {
     /// Receive one packet from the connected TcpStream
     ///
     /// ```no_run
-    /// use lurk_lcsc::Protocol;
+    /// use lurk_protocol::Protocol;
     /// use std::net::TcpStream;
     /// use std::sync::Arc;
     ///


### PR DESCRIPTION
Changed the name from `lurk_lcsc` to `lurk_protocol` to better describe the crate